### PR TITLE
Update ResourceCollection.php

### DIFF
--- a/src/Helper/ResourceCollection.php
+++ b/src/Helper/ResourceCollection.php
@@ -209,7 +209,7 @@ class ResourceCollection implements IteratorAggregate, PaginationLinkProviderInt
                 $sourceAlias = $relations[$relation['entity']]['alias'];
             }
 
-            $this->query->join(sprintf('%s.%s', $sourceAlias, $relation['entity']), $relation['alias']);
+            $this->query->leftJoin(sprintf('%s.%s', $sourceAlias, $relation['entity']), $relation['alias']);
         }
     }
 }


### PR DESCRIPTION
With a innerJoin data some results are removed when sorting on fields. By changing it to leftJoin, you can sort without removing results.

This only happens when you sort on fields that are empty.