### PR TITLE
Feature/doctrine embeddable

### DIFF
--- a/src/Helper/FieldManager.php
+++ b/src/Helper/FieldManager.php
@@ -188,14 +188,15 @@ class FieldManager
     protected function getProcessedField($fieldName): array
     {
         $entity = $this->rootEntity;
-        $explodedField = explode('.', $fieldName);
+        $explodedField = \explode('.', $fieldName);
+        $numParts = \count($explodedField);
 
-        if (count($explodedField) === 1) {
+        if (1 === $numParts) {
             return $explodedField;
         }
 
         $field = [];
-        for ($i = 0, $length = count($explodedField); $i < $length; $i++) {
+        for ($i = 0, $length = $numParts; $i < $length; $i++) {
             $fields = $this->entityManager->getClassMetadata($entity)->fieldMappings;
 
             if (!isset($explodedField[$i + 1])) {
@@ -203,7 +204,7 @@ class FieldManager
                 continue;
             }
 
-            if (!isset($fields[$explodedField[$i] . '.' . $explodedField[$i + 1]])) {
+            if (!isset($fields[$explodedField[$i].'.'.$explodedField[$i + 1]])) {
                 $field[] = $explodedField[$i];
 
                 $relationMetaData = $this->getRelationMetaData($entity, $explodedField[$i]);
@@ -211,7 +212,7 @@ class FieldManager
                 continue;
             }
 
-            $field[] = $explodedField[$i] . '.' . $explodedField[$i + 1];
+            $field[] = $explodedField[$i].'.'.$explodedField[$i + 1];
             $i++;
         }
 
@@ -300,7 +301,8 @@ class FieldManager
      *
      * @return array
      */
-    protected function getRelationMetaData($sourceEntity, $entity) {
+    protected function getRelationMetaData($sourceEntity, $entity)
+    {
         $associations = $this->entityManager->getClassMetadata($sourceEntity)->associationMappings;
 
         return $associations[$entity] ?? [];

--- a/src/Helper/FieldManager.php
+++ b/src/Helper/FieldManager.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Paknahad\JsonApiBundle\Helper;
 
 use Doctrine\ORM\EntityManager;
@@ -138,10 +137,11 @@ class FieldManager
      */
     public function getQueryFieldName(string $fieldName): string
     {
+
         return sprintf(
-            '%s.%s',
-            $this->fields[$fieldName]['relation_alias'] ?? self::ROOT_ALIAS,
-            $this->fields[$fieldName]['field']
+          '%s.%s',
+          $this->fields[$fieldName]['relation_alias'] ?? self::ROOT_ALIAS,
+          $this->fields[$fieldName]['field']
         );
     }
 
@@ -166,15 +166,56 @@ class FieldManager
      */
     protected function parseField($fieldName): array
     {
-        $explodedField = explode('.', $fieldName);
-        $finalField = array_pop($explodedField);
-        $entity = !empty($explodedField) ? array_shift($explodedField) : $this->getRootEntity();
+        $processedField = $this->getProcessedField($fieldName);
+
+        $finalField = array_pop($processedField);
+        $entity = !empty($processedField) ? array_shift($processedField) : $this->getRootEntity();
 
         return [
-            'field' => $finalField,
-            'entity-path' => $explodedField,
-            'entity' => $entity,
+          'field' => $finalField,
+          'entity-path' => $processedField,
+          'entity' => $entity,
         ];
+    }
+
+    /**
+     * Get an indexed array with entities and actual fields separated.
+     *
+     * @param $fieldName
+     *
+     * @return array
+     */
+    protected function getProcessedField($fieldName): array
+    {
+        $entity = $this->rootEntity;
+        $explodedField = explode('.', $fieldName);
+
+        if (count($explodedField) === 1) {
+            return $explodedField;
+        }
+
+        $field = [];
+        for ($i = 0, $length = count($explodedField); $i < $length; $i++) {
+            $fields = $this->entityManager->getClassMetadata($entity)->fieldMappings;
+
+            if (!isset($explodedField[$i + 1])) {
+                $field[] = $explodedField[$i];
+                continue;
+            }
+
+            if (!isset($fields[$explodedField[$i] . '.' . $explodedField[$i + 1]])) {
+                $field[] = $explodedField[$i];
+
+                $relationMetaData = $this->getRelationMetaData($entity, $explodedField[$i]);
+                $entity = $relationMetaData['targetEntity'];
+                continue;
+            }
+
+            $field[] = $explodedField[$i] . '.' . $explodedField[$i + 1];
+            $i++;
+        }
+
+        return $field;
     }
 
     /**
@@ -239,15 +280,30 @@ class FieldManager
             $alias = 'r__'.$iterator++;
         }
 
-        $associations = $this->entityManager->getClassMetadata($sourceEntity)->associationMappings;
+        $relationMetaData = $this->getRelatiionMetaData($sourceEntity, $entity);
 
         $this->relations[$entity] = [
-            'entity' => $associations[$entity]['fieldName'] ?? null,
-            'entityClass' => $associations[$entity]['targetEntity'] ?? $entity,
-            'sourceEntity' => $sourceEntity,
-            'alias' => $alias,
+          'entity' => $relationMetaData['fieldName'] ?? null,
+          'entityClass' => $relationMetaData['targetEntity'] ?? $entity,
+          'sourceEntity' => $sourceEntity,
+          'alias' => $alias,
         ];
 
         return $this->relations[$entity]['entityClass'];
     }
+
+    /**
+     * Get the relation metadata for the provided entity.
+     *
+     * @param $sourceEntity
+     * @param $entity
+     *
+     * @return array
+     */
+    protected function getRelationMetaData($sourceEntity, $entity) {
+        $associations = $this->entityManager->getClassMetadata($sourceEntity)->associationMappings;
+
+        return $associations[$entity] ?? [];
+    }
+
 }

--- a/src/Helper/FieldManager.php
+++ b/src/Helper/FieldManager.php
@@ -139,9 +139,9 @@ class FieldManager
     public function getQueryFieldName(string $fieldName): string
     {
         return sprintf(
-            '%s.%s',
-            $this->fields[$fieldName]['relation_alias'] ?? self::ROOT_ALIAS,
-            $this->fields[$fieldName]['field']
+          '%s.%s',
+          $this->fields[$fieldName]['relation_alias'] ?? self::ROOT_ALIAS,
+          $this->fields[$fieldName]['field']
         );
     }
 
@@ -172,9 +172,9 @@ class FieldManager
         $entity = !empty($processedField) ? array_shift($processedField) : $this->getRootEntity();
 
         return [
-            'field' => $finalField,
-            'entity-path' => $processedField,
-            'entity' => $entity,
+          'field' => $finalField,
+          'entity-path' => $processedField,
+          'entity' => $entity,
         ];
     }
 
@@ -188,7 +188,7 @@ class FieldManager
     protected function getProcessedField($fieldName): array
     {
         $entity = $this->rootEntity;
-        $explodedField = \explode('.', $fieldName);
+        $explodedField = explode('.', $fieldName);
         $numParts = \count($explodedField);
 
         if (1 === $numParts) {
@@ -196,7 +196,7 @@ class FieldManager
         }
 
         $field = [];
-        for ($i = 0, $length = $numParts; $i < $length; $i++) {
+        for ($i = 0, $length = $numParts; $i < $length; ++$i) {
             $fields = $this->entityManager->getClassMetadata($entity)->fieldMappings;
 
             if (!isset($explodedField[$i + 1])) {
@@ -213,7 +213,7 @@ class FieldManager
             }
 
             $field[] = $explodedField[$i].'.'.$explodedField[$i + 1];
-            $i++;
+            ++$i;
         }
 
         return $field;
@@ -281,13 +281,13 @@ class FieldManager
             $alias = 'r__'.$iterator++;
         }
 
-        $relationMetaData = $this->getRelatiionMetaData($sourceEntity, $entity);
+        $relationMetaData = $this->getRelationMetaData($sourceEntity, $entity);
 
         $this->relations[$entity] = [
-            'entity' => $relationMetaData['fieldName'] ?? null,
-            'entityClass' => $relationMetaData['targetEntity'] ?? $entity,
-            'sourceEntity' => $sourceEntity,
-            'alias' => $alias,
+          'entity' => $relationMetaData['fieldName'] ?? null,
+          'entityClass' => $relationMetaData['targetEntity'] ?? $entity,
+          'sourceEntity' => $sourceEntity,
+          'alias' => $alias,
         ];
 
         return $this->relations[$entity]['entityClass'];

--- a/src/Helper/FieldManager.php
+++ b/src/Helper/FieldManager.php
@@ -138,7 +138,6 @@ class FieldManager
      */
     public function getQueryFieldName(string $fieldName): string
     {
-
         return sprintf(
             '%s.%s',
             $this->fields[$fieldName]['relation_alias'] ?? self::ROOT_ALIAS,

--- a/src/Helper/FieldManager.php
+++ b/src/Helper/FieldManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Paknahad\JsonApiBundle\Helper;
 
 use Doctrine\ORM\EntityManager;
@@ -139,9 +140,9 @@ class FieldManager
     {
 
         return sprintf(
-          '%s.%s',
-          $this->fields[$fieldName]['relation_alias'] ?? self::ROOT_ALIAS,
-          $this->fields[$fieldName]['field']
+            '%s.%s',
+            $this->fields[$fieldName]['relation_alias'] ?? self::ROOT_ALIAS,
+            $this->fields[$fieldName]['field']
         );
     }
 
@@ -172,9 +173,9 @@ class FieldManager
         $entity = !empty($processedField) ? array_shift($processedField) : $this->getRootEntity();
 
         return [
-          'field' => $finalField,
-          'entity-path' => $processedField,
-          'entity' => $entity,
+            'field' => $finalField,
+            'entity-path' => $processedField,
+            'entity' => $entity,
         ];
     }
 
@@ -283,10 +284,10 @@ class FieldManager
         $relationMetaData = $this->getRelatiionMetaData($sourceEntity, $entity);
 
         $this->relations[$entity] = [
-          'entity' => $relationMetaData['fieldName'] ?? null,
-          'entityClass' => $relationMetaData['targetEntity'] ?? $entity,
-          'sourceEntity' => $sourceEntity,
-          'alias' => $alias,
+            'entity' => $relationMetaData['fieldName'] ?? null,
+            'entityClass' => $relationMetaData['targetEntity'] ?? $entity,
+            'sourceEntity' => $sourceEntity,
+            'alias' => $alias,
         ];
 
         return $this->relations[$entity]['entityClass'];


### PR DESCRIPTION
Adds support for Doctrine embeddable entities.

The field has more complex parsing that checks if the current and next in the . split is actually a field on the current entity.

This is required because Doctrine embeddable entities will use a . in the fieldname.