### PR TITLE
Allow removing a relation via a relationship update.

### DIFF
--- a/src/Hydrator/ValidatorTrait.php
+++ b/src/Hydrator/ValidatorTrait.php
@@ -30,10 +30,18 @@ trait ValidatorTrait
     protected function validateRelationType($relation, array $validTypes): void
     {
         if ($relation instanceof ToOneRelationship) {
+            if (!$relation->getResourceIdentifier()) {
+                return;
+            }
+
             if (!\in_array($relation->getResourceIdentifier()->getType(), $validTypes, true)) {
                 throw new ValidatorException('Invalid type: '.$relation->getResourceIdentifier()->getType());
             }
         } elseif ($relation instanceof ToManyRelationship) {
+            if (!$relation->getResourceIdentifiers()) {
+                return;
+            }
+
             foreach (array_unique($relation->getResourceIdentifierTypes()) as $type) {
                 if (!\in_array($type, $validTypes, true)) {
                     throw new ValidatorException('Invalid type: '.$type);

--- a/src/Resources/skeleton/api/JsonApi/Hydrator/AbstractEntityHydrator.tpl.php
+++ b/src/Resources/skeleton/api/JsonApi/Hydrator/AbstractEntityHydrator.tpl.php
@@ -132,11 +132,16 @@ abstract class Abstract<?= $entity_class_name ?>Hydrator extends AbstractHydrato
             '<?= $association['field_name'] ?>' => function (<?= $entity_class_name ?> &$<?= $entity_var_name ?>, ToOneRelationship $<?= $association['field_name'] ?>, $data, $relationshipName) {
                 $this->validateRelationType($<?= $association['field_name'] ?>, ['<?= $association['target_entity_type']?>']);
 
-                $association = $this->objectManager->getRepository('<?= $association['target_entity']?>')
-                    ->find($<?= $association['field_name'] ?>->getResourceIdentifier()->getId());
 
-                if (is_null($association)) {
-                    throw new InvalidRelationshipValueException($relationshipName, [$<?= $association['field_name'] ?>->getResourceIdentifier()->getId()]);
+                $association = null;
+                $id = $<?= $association['field_name'] ?>->getResourceIdentifier();
+                if ($id) {
+                    $association = $this->objectManager->getRepository('<?= $association['target_entity']?>')
+                        ->find($<?= $association['field_name'] ?>->getResourceIdentifier()->getId());
+
+                    if (is_null($association)) {
+                        throw new InvalidRelationshipValueException($relationshipName, [$<?= $association['field_name'] ?>->getResourceIdentifier()->getId()]);
+                    }
                 }
 
                 $<?= $entity_var_name ?>-><?= $association['setter'] ?>($association);


### PR DESCRIPTION
This change allows you to implement:
https://jsonapi.org/format/#crud-updating-to-one-relationships

Right now a relation is always required making it impossible to remove a relation. I added some checks to allow empty relations. I tested this behavior and it works just fine.

The PR does not include adding routes yet though. Unfortunately I don't have the time to include a complete implementation.

Would you consider merging this PR and making a separate issue to introduce the new paths?
 