### PR TITLE
Unique and nullable field attributes are now false by default

### DIFF
--- a/src/Maker/ApiCrud.php
+++ b/src/Maker/ApiCrud.php
@@ -315,8 +315,8 @@ final class ApiCrud extends AbstractMaker
                 'id' => isset($field['id']) && $field['id'],
                 'name' => $field['fieldName'],
                 'type' => $field['type'],
-                'unique' => $field['unique'],
-                'nullable' => $field['nullable'],
+                'unique' => $field['unique'] ?? false,
+                'nullable' => $field['nullable'] ?? false,
                 'getter' => 'get'.Str::asCamelCase($field['fieldName']),
                 'setter' => 'set'.Str::asCamelCase($field['fieldName']),
             ];


### PR DESCRIPTION
When using 3rd party bundles ( eg. FOSUser bundle ) sometimes they do not define unique or nullable attributes in their entity xml mappings.
This fix sets unique and nullable attributes to false by default.