### PR TITLE
Feature/update

### DIFF
--- a/src/Collection/CollectionGeneratorAbstract.php
+++ b/src/Collection/CollectionGeneratorAbstract.php
@@ -30,6 +30,11 @@ abstract class CollectionGeneratorAbstract
         $this->rootDirectory = $rootDirectory;
     }
 
+    public function setSeed(int $int)
+    {
+        srand($int);
+    }
+
     abstract public function generateCollection(ClassMetadataInfo $classMetadata, string $entityName, string $route): ?string;
 
     protected function getActionsList(string $entityName): array

--- a/src/Collection/OpenApi/Attributes.php
+++ b/src/Collection/OpenApi/Attributes.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\Attribute;
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\Relation;
+use phootwork\collection\Map;
+
+class Attributes
+{
+    /** @var Map */
+    private $fields;
+
+    /** @var Map */
+    private $relations;
+
+    private function __construct()
+    {
+        $this->fields = new Map();
+        $this->relations = new Map();
+    }
+
+    public static function parse(ClassMetadataInfo $classMetadata): self
+    {
+        $attributes = new self();
+
+        foreach ($classMetadata->fieldMappings as $field) {
+            $attributes->addField(new Attribute($field));
+        }
+
+        foreach ($classMetadata->associationMappings as $relation) {
+            $attributes->addRelation(new Relation($relation));
+        }
+
+        return $attributes;
+    }
+
+    private function addField(Attribute $field): void
+    {
+        $this->fields->set($field->get('fieldName'), $field);
+    }
+
+    private function addRelation(Relation $relation): void
+    {
+        $this->relations->set($relation->get('fieldName'), $relation);
+    }
+
+    public function getFieldsSchema()
+    {
+        $result = [];
+        $this->fields->each(function (string $key, Attribute $field) use (&$result) {
+            if (!$field->isPrimaryKey()) {
+                $result = array_merge($result, $field->toArray());
+            }
+        });
+
+        return [
+            'type' => 'object',
+            'properties' => $result,
+        ];
+    }
+
+    public function getRelationsSchemas()
+    {
+        $result = [];
+        $this->relations->each(function (string $key, Relation $relation) use (&$result) {
+            $result[$relation->generateName()] = [
+                'type' => 'object',
+                'properties' => $relation->toArray(),
+            ];
+        });
+
+        return $result;
+    }
+
+    public function getRelations()
+    {
+        $result = [];
+        $this->relations->each(function (string $key, Relation $relation) use (&$result) {
+            $result = array_merge($result, $relation->getDefinitionPath());
+        });
+
+        return ['properties' => $result];
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Attribute.php
+++ b/src/Collection/OpenApi/JsonApi/Attribute.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+class Attribute extends AttributeAbstract
+{
+    public function isPrimaryKey(): bool
+    {
+        return $this->metadata->has('id') && (bool) ($this->get('id'));
+    }
+
+    public function toArray()
+    {
+        $array = [$this->get('fieldName') => $this->getSwaggerType()];
+
+        return $array;
+    }
+
+    private function getSwaggerType()
+    {
+        switch ($this->get('type')) {
+            case 'json':
+                return [
+                    'type' => 'object',
+                ];
+
+            case 'float':
+            case 'decimal':
+                return [
+                    'type' => 'number',
+                    'format' => $this->get('type'),
+                ];
+
+            case 'smallint':
+            case 'bigint':
+            case 'integer':
+                return [
+                    'type' => 'integer',
+                    'format' => ('bigint' === $this->get('type')) ? 'int64' : 'int32',
+                ];
+
+            case 'date':
+            case 'date_immutable':
+                return [
+                    'type' => 'string',
+                    'format' => 'date',
+                ];
+
+            case 'datetime':
+            case 'datetime_immutable':
+            case 'datetimetz':
+            case 'datetimetz_immutable':
+                return [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                ];
+
+            default:
+                return [
+                    'type' => $this->get('type'),
+                ];
+        }
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Attribute.php
+++ b/src/Collection/OpenApi/JsonApi/Attribute.php
@@ -19,6 +19,7 @@ class Attribute extends AttributeAbstract
     private function getSwaggerType()
     {
         switch ($this->get('type')) {
+            case 'array':
             case 'json':
                 return [
                     'type' => 'object',

--- a/src/Collection/OpenApi/JsonApi/AttributeAbstract.php
+++ b/src/Collection/OpenApi/JsonApi/AttributeAbstract.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use phootwork\collection\CollectionUtils;
+
+abstract class AttributeAbstract
+{
+    protected $metadata;
+
+    public function __construct(array $metadata)
+    {
+        $this->metadata = CollectionUtils::toMap($metadata);
+    }
+
+    public function get(string $name)
+    {
+        return $this->metadata->get($name);
+    }
+
+    abstract public function toArray();
+}

--- a/src/Collection/OpenApi/JsonApi/DataAbstract.php
+++ b/src/Collection/OpenApi/JsonApi/DataAbstract.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\OpenApi\Attributes;
+use Paknahad\JsonApiBundle\JsonApiStr;
+
+abstract class DataAbstract
+{
+    /** @var Attributes */
+    private $attributes;
+
+    protected $entityName;
+    protected $actionName;
+    protected $route;
+
+    public function __construct(string $entityName, Attributes $attributes, string $actionName, string $route)
+    {
+        $this->entityName = $entityName;
+        $this->actionName = $actionName;
+        $this->attributes = $attributes;
+        $this->route = $route;
+    }
+
+    abstract public function toArray(): array;
+
+    protected function genJsonApiDataBody(bool $containId = false): array
+    {
+        if ($containId) {
+            $idProperties = [
+                'id' => [
+                    'type' => 'integer',
+                    'format' => 'int64',
+                    'example' => 12,
+                ],
+            ];
+        } else {
+            $idProperties = [];
+        }
+
+        return [
+            'type' => 'object',
+            'properties' => array_merge(
+                $idProperties,
+                [
+                    'type' => ['type' => 'string', 'example' => JsonApiStr::entityNameToType($this->entityName)],
+                    'attributes' => ['$ref' => '#/components/schemas/'.$this->entityName],
+                    'relationships' => $this->attributes->getRelations(),
+                ]
+            ),
+        ];
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Link.php
+++ b/src/Collection/OpenApi/JsonApi/Link.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\CollectionGeneratorAbstract;
+
+class Link
+{
+    public static function generateLinks(string $actionName, string $route): array
+    {
+        $links = [
+            'type' => 'object',
+            'properties' => [
+                'self' => ['type' => 'string', 'example' => $route],
+            ],
+        ];
+
+        if (CollectionGeneratorAbstract::LIST_ACTION === $actionName) {
+            $links['properties'] = [
+                'self' => ['type' => 'string', 'example' => $route.'?page[number]=1&page[size]=100'],
+                'first' => ['type' => 'string', 'example' => $route.'?page[number]=1&page[size]=100'],
+                'last' => ['type' => 'string', 'example' => $route.'?page[number]=1&page[size]=100'],
+                'prev' => ['type' => 'string', 'example' => 'null'],
+                'next' => ['type' => 'string', 'example' => 'null'],
+            ];
+        }
+
+        return $links;
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Parameters.php
+++ b/src/Collection/OpenApi/JsonApi/Parameters.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\CollectionGeneratorAbstract;
+use Paknahad\JsonApiBundle\JsonApiStr;
+use function in_array;
+
+class Parameters extends DataAbstract
+{
+    private function hasPathParam()
+    {
+        return in_array(
+            $this->actionName,
+            [
+                CollectionGeneratorAbstract::VIEW_ACTION,
+                CollectionGeneratorAbstract::DELETE_ACTION,
+                CollectionGeneratorAbstract::EDIT_ACTION,
+            ]
+        );
+    }
+
+
+    private function getPathParams(): ?array
+    {
+        if (!$this->hasPathParam()) {
+            return null;
+        }
+
+        return [
+            'name' => JsonApiStr::genEntityIdName($this->entityName),
+            'in' => 'path',
+            'required' => true,
+            'schema' => ['type' => 'integer',
+                'format' => 'int64',],
+        ];
+    }
+
+    public function toArray(): array
+    {
+        $params = [];
+
+        if ($param = $this->getPathParams()) {
+            $params[] = $param;
+        }
+
+        return $params;
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Relation.php
+++ b/src/Collection/OpenApi/JsonApi/Relation.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Paknahad\JsonApiBundle\JsonApiStr;
+
+class Relation extends AttributeAbstract
+{
+    const RELATIONS_SUFFIX = 'Relation';
+
+    public function toArray()
+    {
+        $array = [
+            'type' => [
+                'type' => 'string',
+                'enum' => [JsonApiStr::entityNameToType($this->get('targetEntity'))],
+                'example' => JsonApiStr::entityNameToType($this->get('targetEntity')),
+            ],
+            'id' => [
+                'type' => 'integer',
+                'minimum' => 1,
+                'description' => JsonApiStr::singularizeClassName($this->get('targetEntity')).' ID',
+                'example' => rand(2, 99),
+            ],
+        ];
+
+        return $array;
+    }
+
+    public function getDefinitionPath()
+    {
+        if (\in_array($this->get('type'), [ClassMetadataInfo::TO_MANY, ClassMetadataInfo::MANY_TO_MANY, ClassMetadataInfo::ONE_TO_MANY])) {
+            $relation = [
+                $this->get('fieldName') => [
+                    'type' => 'array',
+                    'items' => ['$ref' => '#/components/schemas/'.$this->generateName()],
+                ],
+            ];
+        } else {
+            $relation = [$this->get('fieldName') => ['$ref' => '#/components/schemas/'.$this->generateName()]];
+        }
+
+        return $relation;
+    }
+
+    public function generateName()
+    {
+        return JsonApiStr::singularizeClassName($this->get('targetEntity')).self::RELATIONS_SUFFIX;
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/RequestBody.php
+++ b/src/Collection/OpenApi/JsonApi/RequestBody.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\CollectionGeneratorAbstract;
+use Paknahad\JsonApiBundle\JsonApiStr;
+use function in_array;
+
+class RequestBody extends DataAbstract
+{
+    private function hasRequestBody()
+    {
+        return in_array(
+            $this->actionName,
+            [
+                CollectionGeneratorAbstract::ADD_ACTION,
+                CollectionGeneratorAbstract::EDIT_ACTION,
+            ]
+        );
+    }
+
+
+    private function getRequestBody(): ?array
+    {
+        if (!$this->hasRequestBody()) {
+            return [];
+        }
+
+        return [
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'data' => $this->genJsonApiDataBody(true)
+                        ]
+                    ],
+                ]
+            ]
+
+        ];
+    }
+
+    public function toArray(): array
+    {
+        return $this->getRequestBody();
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Response.php
+++ b/src/Collection/OpenApi/JsonApi/Response.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\CollectionGeneratorAbstract;
+
+class Response extends DataAbstract
+{
+    public function toArray(): array
+    {
+        $response = [
+            'jsonapi' => [
+                'type' => 'object',
+                'properties' => [
+                    'version' => ['type' => 'string', 'example' => '1.0'],
+                ],
+            ],
+            'links' => Link::generateLinks($this->actionName, $this->route),
+        ];
+
+        if (CollectionGeneratorAbstract::LIST_ACTION === $this->actionName) {
+            $response['data'] = [
+                'type' => 'array',
+                'items' => $this->genJsonApiDataBody(true),
+            ];
+        } else {
+            $response['data'] = $this->genJsonApiDataBody(true);
+        }
+
+        return [
+            'type' => 'object',
+            'properties' => $response,
+        ];
+    }
+}

--- a/src/Collection/OpenApi/OpenApi.php
+++ b/src/Collection/OpenApi/OpenApi.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi;
+
+use phootwork\collection\ArrayList;
+use phootwork\collection\CollectionUtils;
+use phootwork\collection\Map;
+use phootwork\lang\Arrayable;
+
+class OpenApi implements Arrayable
+{
+    private $content;
+
+    public function __construct(array $collection)
+    {
+        $this->content = CollectionUtils::toMap($collection);
+    }
+
+    public function addDefinition(string $name, array $content): void
+    {
+        $this->add('definitions', $name, $content);
+    }
+
+    public function addPath(string $name, array $content): void
+    {
+        $this->add('paths', $name, $content);
+    }
+
+    private function add(string $name, string $key, array $content): void
+    {
+        if (!$this->content->has($name)) {
+            $this->content->set($name, new Map());
+        }
+
+        $this->content->get($name)->remove($key);
+        $this->content->get($name)->set($key, $content);
+    }
+
+    public function toArray(): array
+    {
+        return self::mapToArray($this->content);
+    }
+
+    /**
+     * @param Map|ArrayList $collection
+     */
+    private function mapToArray($collection): array
+    {
+        $result = $collection->toArray();
+
+        foreach ($result as $key => &$content) {
+            if (\is_object($content)) {
+                $content = self::mapToArray($content);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Collection/OpenApi/Paths.php
+++ b/src/Collection/OpenApi/Paths.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi;
+
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\Parameters;
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\RequestBody;
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\Response;
+use Paknahad\JsonApiBundle\JsonApiStr;
+use function in_array;
+
+class Paths
+{
+    public static function buildPaths(array $actions, string $entityName, string $route, Attributes $attributes): array
+    {
+        $paths = [];
+
+        foreach ($actions as $name => $action) {
+            $path = self::generateUrl($route, $name, $entityName);
+
+            $paths[$path][strtolower($action['method'])] = [
+                'tags' => [JsonApiStr::entityNameToType($entityName)],
+                'summary' => $action['title'],
+                'operationId' => $name . ucfirst($entityName),
+                'parameters' => (new Parameters($entityName, $attributes, $name, $route))->toArray(),
+                'requestBody' => (new RequestBody($entityName, $attributes, $name, $route))->toArray(),
+                'responses' => [
+                    '200' => [
+                        'description' => 'successful operation',
+                        'content' => [
+                            'application/json' => [
+                                'schema' => (new Response($entityName, $attributes, $name, $route))->toArray(),
+                            ]
+
+                        ]
+
+                    ],
+                ],
+            ];
+            if (count($paths[$path][strtolower($action['method'])]['parameters']) === 0) {
+                unset($paths[$path][strtolower($action['method'])]['parameters']);
+            }
+            if (count($paths[$path][strtolower($action['method'])]['requestBody']) === 0) {
+                unset($paths[$path][strtolower($action['method'])]['requestBody']);
+            }
+        }
+
+        return $paths;
+    }
+
+    private static function generateUrl($baseRoute, $actionName, $entityName)
+    {
+        return $baseRoute .
+            (
+            in_array($actionName, ['edit', 'delete', 'view']) ?
+                '/' . JsonApiStr::genEntityIdName($entityName, true) : ''
+            );
+    }
+}

--- a/src/Collection/OpenApiCollectionGenerator.php
+++ b/src/Collection/OpenApiCollectionGenerator.php
@@ -29,7 +29,12 @@ class OpenApiCollectionGenerator extends CollectionGeneratorAbstract
         $this->setSchemas($entityName);
         $this->generateAllPaths($entityName, $route);
 
-        $this->fileManager->dumpFile(self::OPEN_API_PATH, Yaml::dump($this->openApi->toArray(), 20, 2));
+        $arrayFile = $this->openApi->toArray();
+
+        ksort($arrayFile['paths']);
+        ksort($arrayFile['components']['schemas']);
+
+        $this->fileManager->dumpFile(self::OPEN_API_PATH, Yaml::dump($arrayFile, 20, 2));
 
         return self::OPEN_API_PATH;
     }

--- a/src/Collection/OpenApiCollectionGenerator.php
+++ b/src/Collection/OpenApiCollectionGenerator.php
@@ -16,10 +16,12 @@ class OpenApiCollectionGenerator extends CollectionGeneratorAbstract
     private $fields;
 
     const OPEN_API_PATH = 'collections/open_api.yaml';
-    const OPEN_API_TEMPLATE_PATH = __DIR__.'/../Resources/skeleton/open_api.yaml';
+    const OPEN_API_TEMPLATE_PATH = __DIR__ . '/../Resources/skeleton/open_api.yaml';
 
     public function generateCollection(ClassMetadataInfo $classMetadata, string $entityName, string $route): string
     {
+        $this->setSeed(12345678);
+
         $this->openApi = new OpenApi($this->loadOldCollection());
 
         $this->fields = Attributes::parse($classMetadata);
@@ -52,8 +54,8 @@ class OpenApiCollectionGenerator extends CollectionGeneratorAbstract
 
     private function loadOldCollection(): array
     {
-        if (file_exists($this->rootDirectory.'/'.self::OPEN_API_PATH)) {
-            $file = $this->rootDirectory.'/'.self::OPEN_API_PATH;
+        if (file_exists($this->rootDirectory . '/' . self::OPEN_API_PATH)) {
+            $file = $this->rootDirectory . '/' . self::OPEN_API_PATH;
         } else {
             $file = self::OPEN_API_TEMPLATE_PATH;
         }

--- a/src/Collection/OpenApiCollectionGenerator.php
+++ b/src/Collection/OpenApiCollectionGenerator.php
@@ -3,9 +3,9 @@
 namespace Paknahad\JsonApiBundle\Collection;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Paknahad\JsonApiBundle\Collection\Swagger\Attributes;
+use Paknahad\JsonApiBundle\Collection\OpenApi\Attributes;
 use Paknahad\JsonApiBundle\Collection\OpenApi\OpenApi;
-use Paknahad\JsonApiBundle\Collection\Swagger\Paths;
+use Paknahad\JsonApiBundle\Collection\OpenApi\Paths;
 use Symfony\Component\Yaml\Yaml;
 
 class OpenApiCollectionGenerator extends CollectionGeneratorAbstract
@@ -24,7 +24,7 @@ class OpenApiCollectionGenerator extends CollectionGeneratorAbstract
 
         $this->fields = Attributes::parse($classMetadata);
 
-        $this->setDefinitions($entityName);
+        $this->setSchemas($entityName);
         $this->generateAllPaths($entityName, $route);
 
         $this->fileManager->dumpFile(self::OPEN_API_PATH, Yaml::dump($this->openApi->toArray(), 20, 2));
@@ -41,12 +41,12 @@ class OpenApiCollectionGenerator extends CollectionGeneratorAbstract
         }
     }
 
-    private function setDefinitions(string $entityName): void
+    private function setSchemas(string $entityName): void
     {
-        $this->openApi->addDefinition($entityName, $this->fields->getFieldsSchema());
+        $this->openApi->addSchema($entityName, $this->fields->getFieldsSchema());
 
         foreach ($this->fields->getRelationsSchemas() as $name => $schema) {
-            $this->openApi->addDefinition($name, $schema);
+            $this->openApi->addSchema($name, $schema);
         }
     }
 

--- a/src/Collection/OpenApiCollectionGenerator.php
+++ b/src/Collection/OpenApiCollectionGenerator.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Paknahad\JsonApiBundle\Collection\Swagger\Attributes;
+use Paknahad\JsonApiBundle\Collection\OpenApi\OpenApi;
+use Paknahad\JsonApiBundle\Collection\Swagger\Paths;
+use Symfony\Component\Yaml\Yaml;
+
+class OpenApiCollectionGenerator extends CollectionGeneratorAbstract
+{
+    /** @var OpenApi */
+    private $openApi;
+    /** @var Attributes */
+    private $fields;
+
+    const OPEN_API_PATH = 'collections/open_api.yaml';
+    const OPEN_API_TEMPLATE_PATH = __DIR__.'/../Resources/skeleton/open_api.yaml';
+
+    public function generateCollection(ClassMetadataInfo $classMetadata, string $entityName, string $route): string
+    {
+        $this->openApi = new OpenApi($this->loadOldCollection());
+
+        $this->fields = Attributes::parse($classMetadata);
+
+        $this->setDefinitions($entityName);
+        $this->generateAllPaths($entityName, $route);
+
+        $this->fileManager->dumpFile(self::OPEN_API_PATH, Yaml::dump($this->openApi->toArray(), 20, 2));
+
+        return self::OPEN_API_PATH;
+    }
+
+    private function generateAllPaths(string $entityName, string $route): void
+    {
+        $paths = Paths::buildPaths($this->getActionsList($entityName), $entityName, $route, $this->fields);
+
+        foreach ($paths as $path => $content) {
+            $this->openApi->addPath($path, $content);
+        }
+    }
+
+    private function setDefinitions(string $entityName): void
+    {
+        $this->openApi->addDefinition($entityName, $this->fields->getFieldsSchema());
+
+        foreach ($this->fields->getRelationsSchemas() as $name => $schema) {
+            $this->openApi->addDefinition($name, $schema);
+        }
+    }
+
+    private function loadOldCollection(): array
+    {
+        if (file_exists($this->rootDirectory.'/'.self::OPEN_API_PATH)) {
+            $file = $this->rootDirectory.'/'.self::OPEN_API_PATH;
+        } else {
+            $file = self::OPEN_API_TEMPLATE_PATH;
+        }
+
+        return Yaml::parseFile($file);
+    }
+}

--- a/src/Collection/PostmanCollectionGenerator.php
+++ b/src/Collection/PostmanCollectionGenerator.php
@@ -36,7 +36,7 @@ class PostmanCollectionGenerator extends CollectionGeneratorAbstract
                     'body' => in_array($name, ['add', 'edit']) ?
                         $this->generateBody($entityName, $action['method'], $classMetadata) : '',
                     'url' => [
-                        'raw' => '{{host}}'.$route.(in_array($name, ['add', 'list']) ? '/' : '/1'),
+                        'raw' => '{{host}}'.$route.(in_array($name, ['add', 'list']) ? '' : '/1'),
                         'host' => [
                             '{{host}}',
                         ],

--- a/src/Collection/SwaggerCollectionGenerator.php
+++ b/src/Collection/SwaggerCollectionGenerator.php
@@ -16,10 +16,12 @@ class SwaggerCollectionGenerator extends CollectionGeneratorAbstract
     private $fields;
 
     const SWAGGER_PATH = 'collections/swagger.yaml';
-    const SWAGGER_TEMPLATE_PATH = __DIR__.'/../Resources/skeleton/swagger.yaml';
+    const SWAGGER_TEMPLATE_PATH = __DIR__ . '/../Resources/skeleton/swagger.yaml';
 
     public function generateCollection(ClassMetadataInfo $classMetadata, string $entityName, string $route): string
     {
+        $this->setSeed(12345678);
+
         $this->swagger = new Swagger($this->loadOldCollection());
 
         $this->fields = Attributes::parse($classMetadata);
@@ -52,8 +54,8 @@ class SwaggerCollectionGenerator extends CollectionGeneratorAbstract
 
     private function loadOldCollection(): array
     {
-        if (file_exists($this->rootDirectory.'/'.self::SWAGGER_PATH)) {
-            $file = $this->rootDirectory.'/'.self::SWAGGER_PATH;
+        if (file_exists($this->rootDirectory . '/' . self::SWAGGER_PATH)) {
+            $file = $this->rootDirectory . '/' . self::SWAGGER_PATH;
         } else {
             $file = self::SWAGGER_TEMPLATE_PATH;
         }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Paknahad\JsonApiBundle\DependencyInjection;
+
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('json_api');
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode
+            ->children()
+            ->scalarNode('documentation')->defaultValue('swagger')->end()
+            ->scalarNode('controller_namespace')->defaultValue('..\\Controller\\')->end()
+            ->end()
+        ;
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
             ->scalarNode('documentation')->defaultValue('swagger')->end()
-            ->scalarNode('controller_namespace')->defaultValue('..\\Controller\\')->end()
+            ->scalarNode('controller_namespace')->defaultValue('Controller\\')->end()
             ->end()
         ;
         return $treeBuilder;

--- a/src/DependencyInjection/JsonApiExtension.php
+++ b/src/DependencyInjection/JsonApiExtension.php
@@ -21,5 +21,11 @@ class JsonApiExtension extends Extension
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $definition = $container->getDefinition('maker.maker.make_api');
+        $definition->setArgument(0, $config['documentation']);
+        $definition->setArgument(1, $config['controller_namespace']);
     }
 }

--- a/src/EventSubscriber/JsonApiErrorHandlerEvent.php
+++ b/src/EventSubscriber/JsonApiErrorHandlerEvent.php
@@ -56,9 +56,15 @@ class JsonApiErrorHandlerEvent implements EventSubscriberInterface
 
         $additionalMeta = \in_array($this->environment, ['dev', 'test']) ? $this->getExceptionMeta($exception) : [];
 
+        $code = $exception->getCode();
+
+        if($code === 0){
+            $code = null;
+        }
+
         $response = $responder->genericError(
             $this->toErrorDocument($exception, $event->getRequest()->getRequestUri()),
-            null,
+            $code,
             $additionalMeta
         );
 

--- a/src/Maker/ApiCrud.php
+++ b/src/Maker/ApiCrud.php
@@ -7,20 +7,30 @@ use Doctrine\Common\Inflector\Inflector;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Paknahad\JsonApiBundle\Collection\PostmanCollectionGenerator;
 use Paknahad\JsonApiBundle\Collection\SwaggerCollectionGenerator;
-use Symfony\Component\Routing\Annotation\Route;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\PrettyPrinter;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Parser\Php7;
+use PhpParser\Lexer;
+use ReflectionClass;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Doctrine\EntityDetails;
+use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\ClassDetails;
+use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Validation;
 
 /**
@@ -31,12 +41,19 @@ final class ApiCrud extends AbstractMaker
     private $postmanGenerator;
     private $swaggerGenerator;
     private $doctrineHelper;
+    private $fileManager;
+    /**
+     * @var NodeFactory
+     */
+    private $nodeFactory;
 
-    public function __construct(PostmanCollectionGenerator $postmanGenerator, SwaggerCollectionGenerator $swaggerGenerator, DoctrineHelper $doctrineHelper)
+    public function __construct(PostmanCollectionGenerator $postmanGenerator, SwaggerCollectionGenerator $swaggerGenerator, DoctrineHelper $doctrineHelper, FileManager $fileManager, NodeFactory $nodeFactory)
     {
         $this->postmanGenerator = $postmanGenerator;
         $this->swaggerGenerator = $swaggerGenerator;
         $this->doctrineHelper = $doctrineHelper;
+        $this->fileManager = $fileManager;
+        $this->nodeFactory = $nodeFactory;
     }
 
     public static function getCommandName(): string
@@ -56,8 +73,7 @@ final class ApiCrud extends AbstractMaker
                 InputArgument::OPTIONAL,
                 sprintf('The class name of the entity to create API (e.g. <fg=yellow>%s</>)', Str::asClassName(Str::getRandomTerm()))
             )
-            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeCrud.txt'))
-        ;
+            ->setHelp(file_get_contents(__DIR__ . '/../Resources/help/MakeCrud.txt'));
 
         $inputConfig->setArgumentAsNonInteractive('entity-class');
     }
@@ -95,7 +111,7 @@ final class ApiCrud extends AbstractMaker
         if ($entityMetadata) {
             $entityDoctrineDetails = new EntityDetails($entityMetadata);
             $repositoryClassDetails = $generator->createClassNameDetails(
-                '\\'.$entityDoctrineDetails->getRepositoryClass(),
+                '\\' . $entityDoctrineDetails->getRepositoryClass(),
                 'Repository\\',
                 'Repository'
             );
@@ -112,18 +128,18 @@ final class ApiCrud extends AbstractMaker
 
         $controllerClassDetails = $generator->createClassNameDetails(
             $entityVarSingular,
-            'Controller\\',
+            'Controller\\Api\\', // TODO add config dir
             'Controller'
         );
 
         $documentClassDetails = $generator->createClassNameDetails(
             $entityVarSingular,
-            'JsonApi\\Document\\'.$entityClassDetails->getShortName(),
+            'JsonApi\\Document\\' . $entityClassDetails->getShortName(),
             'Document'
         );
         $documentsClassDetails = $generator->createClassNameDetails(
             $entityVarPlural,
-            'JsonApi\\Document\\'.$entityClassDetails->getShortName(),
+            'JsonApi\\Document\\' . $entityClassDetails->getShortName(),
             'Document'
         );
         $transformerClassDetails = $generator->createClassNameDetails(
@@ -134,7 +150,7 @@ final class ApiCrud extends AbstractMaker
 
         foreach (['abstract', 'create', 'update'] as $key) {
             $hydratorClassDetails[$key] = $generator->createClassNameDetails(
-                ucfirst($key).$entityVarSingular,
+                ucfirst($key) . $entityVarSingular,
                 sprintf('JsonApi\\Hydrator\\%s', $entityClassDetails->getShortName()),
                 'Hydrator'
             );
@@ -144,83 +160,183 @@ final class ApiCrud extends AbstractMaker
 
         $routeName = Str::asRouteName($entityVarPlural);
         $routePath = Str::asRoutePath($entityVarPlural);
-        $skeletonPath = __DIR__.'/../Resources/skeleton/';
+        $skeletonPath = __DIR__ . '/../Resources/skeleton/';
 
-        $generator->generateClass(
-            $controllerClassDetails->getFullName(),
-            $skeletonPath.'api/controller/Controller.tpl.php',
-            array_merge(
+
+        $classExists = class_exists($controllerClassDetails->getFullName());
+        if (!$classExists) {
+
+            $generator->generateClass(
+                $controllerClassDetails->getFullName(),
+                $skeletonPath . 'api/controller/Controller.tpl.php',
+                array_merge(
+                    [
+                        'entity_full_class_name' => $entityClassDetails->getFullName(),
+                        'entity_class_name' => $entityClassDetails->getShortName(),
+                        'route_path' => $routePath,
+                        'route_name' => $routeName,
+                        'entity_var_plural' => $entityVarPlural,
+                        'entity_type_var_plural' => $entityTypeVarPlural,
+                        'entity_var_singular' => $entityVarSingular,
+                        'entity_var_name' => lcfirst($entityVarSingular),
+                        'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
+                        'document_full_class_name' => $documentClassDetails->getFullname(),
+                        'document_class_name' => $documentClassDetails->getShortName(),
+                        'documents_full_class_name' => $documentsClassDetails->getFullname(),
+                        'documents_class_name' => $documentsClassDetails->getShortName(),
+                        'create_hydrator_full_class_name' => $hydratorClassDetails['create']->getFullname(),
+                        'create_hydrator_class_name' => $hydratorClassDetails['create']->getShortName(),
+                        'update_hydrator_full_class_name' => $hydratorClassDetails['update']->getFullname(),
+                        'update_hydrator_class_name' => $hydratorClassDetails['update']->getShortName(),
+                        'transformer_full_class_name' => $transformerClassDetails->getFullname(),
+                        'transformer_class_name' => $transformerClassDetails->getShortName(),
+                    ],
+                    $repositoryVars
+                )
+            );
+        } else {
+            $this->writeWarning('Controller class already exists, skipping..', $io);
+        }
+
+        $classExists = class_exists($documentClassDetails->getFullName());
+        if (!$classExists) {
+            $generator->generateClass(
+                $documentClassDetails->getFullName(),
+                $skeletonPath . 'api/JsonApi/Document/EntityDocument.tpl.php',
                 [
-                    'entity_full_class_name' => $entityClassDetails->getFullName(),
-                    'entity_class_name' => $entityClassDetails->getShortName(),
                     'route_path' => $routePath,
-                    'route_name' => $routeName,
-                    'entity_var_plural' => $entityVarPlural,
-                    'entity_type_var_plural' => $entityTypeVarPlural,
-                    'entity_var_singular' => $entityVarSingular,
-                    'entity_var_name' => lcfirst($entityVarSingular),
-                    'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
-                    'document_full_class_name' => $documentClassDetails->getFullname(),
-                    'document_class_name' => $documentClassDetails->getShortName(),
-                    'documents_full_class_name' => $documentsClassDetails->getFullname(),
-                    'documents_class_name' => $documentsClassDetails->getShortName(),
-                    'create_hydrator_full_class_name' => $hydratorClassDetails['create']->getFullname(),
-                    'create_hydrator_class_name' => $hydratorClassDetails['create']->getShortName(),
-                    'update_hydrator_full_class_name' => $hydratorClassDetails['update']->getFullname(),
-                    'update_hydrator_class_name' => $hydratorClassDetails['update']->getShortName(),
-                    'transformer_full_class_name' => $transformerClassDetails->getFullname(),
-                    'transformer_class_name' => $transformerClassDetails->getShortName(),
-                ],
-                $repositoryVars
-            )
-        );
+                    'entity_class_name' => $entityClassDetails->getShortName(),
+                    'namespace' => $documentClassDetails->getFullName(),
+                ]
+            );
 
-        $generator->generateClass(
-            $documentClassDetails->getFullName(),
-            $skeletonPath.'api/JsonApi/Document/EntityDocument.tpl.php',
-            [
-                'route_path' => $routePath,
-                'entity_class_name' => $entityClassDetails->getShortName(),
-                'namespace' => $documentClassDetails->getFullName(),
-            ]
-        );
-
-        $generator->generateClass(
-            $documentsClassDetails->getFullName(),
-            $skeletonPath.'api/JsonApi/Document/EntitiesDocument.tpl.php',
-            [
-                'route_path' => $routePath,
-                'entity_class_name' => $entityClassDetails->getShortName(),
-                'entity_class_name_plural' => $entityVarPlural,
-                'namespace' => $documentsClassDetails->getFullName(),
-            ]
-        );
-
+        } else {
+            $this->writeWarning('Document class already exists, skipping..', $io);
+        }
+        $classExists = class_exists($documentsClassDetails->getFullName());
+        if (!$classExists) {
+            $generator->generateClass(
+                $documentsClassDetails->getFullName(),
+                $skeletonPath . 'api/JsonApi/Document/EntitiesDocument.tpl.php',
+                [
+                    'route_path' => $routePath,
+                    'entity_class_name' => $entityClassDetails->getShortName(),
+                    'entity_class_name_plural' => $entityVarPlural,
+                    'namespace' => $documentsClassDetails->getFullName(),
+                ]
+            );
+        } else {
+            $this->writeWarning('Documents class already exists, skipping..', $io);
+        }
         $toMayTypes = [
             ClassMetadataInfo::TO_MANY,
             ClassMetadataInfo::MANY_TO_MANY,
             ClassMetadataInfo::ONE_TO_MANY,
         ];
-        $generator->generateClass(
-            $transformerClassDetails->getFullName(),
-            $skeletonPath.'api/JsonApi/Transformer/EntityResourceTransformer.tpl.php',
-            [
-                'route_path' => $routePath,
-                'entity_full_class_name' => $entityClassDetails->getFullName(),
-                'entity_class_name' => $entityClassDetails->getShortName(),
-                'entity_var_name' => lcfirst($entityVarSingular),
-                'entity_type_var_plural' => $entityTypeVarPlural,
-                'namespace' => $transformerClassDetails->getFullName(),
-                'fields' => $fields,
-                'associations' => $associations,
-                'to_many_types' => $toMayTypes,
-            ]
-        );
 
+        $classExists = class_exists($transformerClassDetails->getFullName());
+
+        if (!$classExists) {
+            $generator->generateClass(
+                $transformerClassDetails->getFullName(),
+                $skeletonPath . 'api/JsonApi/Transformer/EntityResourceTransformer.tpl.php',
+                [
+                    'route_path' => $routePath,
+                    'entity_full_class_name' => $entityClassDetails->getFullName(),
+                    'entity_class_name' => $entityClassDetails->getShortName(),
+                    'entity_var_name' => lcfirst($entityVarSingular),
+                    'entity_type_var_plural' => $entityTypeVarPlural,
+                    'namespace' => $transformerClassDetails->getFullName(),
+                    'fields' => $fields,
+                    'associations' => $associations,
+                    'to_many_types' => $toMayTypes,
+                ]
+            );
+
+        } else {
+            $transformerPath = $this->getPathOfClass($transformerClassDetails->getFullName());
+            $manipulator = new ClassSourceManipulator($this->fileManager->getFileContents($transformerPath), true);
+            $manipulator->setIo($io);
+
+            $propertyNames = $this->getPropertyNames($entityClassDetails->getFullName());
+            $propertyNames = array_diff($propertyNames, ['id']);
+
+
+            $traverser = new NodeTraverser;
+            $traverser->addVisitor(new class($propertyNames, $entityClassDetails->getShortName()) extends NodeVisitorAbstract {
+
+                private $className;
+
+                public function __construct($propertyNames, $className) {
+                    $this->propertyNames = $propertyNames;
+                    $this->className = $className;
+                }
+
+                public function leaveNode(Node $node)
+                {
+                    if ($node instanceof Node\Stmt\ClassMethod and $node->name->name === 'getAttributes') {
+                        foreach ($node->stmts as $stmt) {
+                            if ($stmt instanceof Node\Stmt\Return_) {
+                                $existingItems = $stmt->expr->items;
+                                $existingItemNames = $stmt->expr->items;
+                                $newItems = [];
+
+                                foreach ($existingItems as $existingItem) {
+                                    $existingItemNames[] = $existingItem->key->value;
+                                }
+
+                                foreach ($this->propertyNames as $propertyName) {
+
+                                    if(!in_array($propertyName, $existingItemNames)){
+                                        $newItems[] = $propertyName;
+                                    }
+                                }
+                                foreach ($newItems as $newItem){
+                                    $key = new Node\Scalar\String_($newItem);
+                                    $type = new Node\Name($this->className);
+                                    $var = new Node\Expr\Variable(lcfirst($this->className));
+                                    $closureParam = new Node\Param($var,null,$type);
+                                    $functionName = 'get'.ucfirst($newItem);
+                                    $expr = new Node\Expr\MethodCall($var,$functionName);
+                                    $return = new Node\Stmt\Return_($expr);
+
+                                    $subNodes = [];
+                                    $subNodes['params'] = [$closureParam];
+                                    $subNodes['stmts'] = [$return];
+
+                                    $closure = new Node\Expr\Closure($subNodes);
+                                    $newAttribute = new Node\Expr\ArrayItem($closure,$key);
+                                    $existingItems[] = $newAttribute;
+                                }
+                                $stmt->expr->items = $existingItems;
+
+
+                            }
+                        }
+                    }
+                }
+            });
+            $lexer = new Lexer\Emulative([
+                'usedAttributes' => [
+                    'comments',
+                    'startLine', 'endLine',
+                    'startTokenPos', 'endTokenPos',
+                ],
+            ]);
+            $parser = new Php7($lexer);
+            $stmts = $parser->parse($this->fileManager->getFileContents($transformerPath));
+            $modifiedStmts = $traverser->traverse($stmts);
+
+            //TODO functions
+            $prettyPrinter = new PrettyPrinter\Standard();
+
+            $this->fileManager->dumpFile($transformerPath, $prettyPrinter->prettyPrintFile($stmts));
+
+        }
         foreach (['abstract', 'create', 'update'] as $key) {
             $generator->generateClass(
                 $hydratorClassDetails[$key]->getFullName(),
-                $skeletonPath.sprintf('api/JsonApi/Hydrator/%sEntityHydrator.tpl.php', ucfirst($key)),
+                $skeletonPath . sprintf('api/JsonApi/Hydrator/%sEntityHydrator.tpl.php', ucfirst($key)),
                 [
                     'route_path' => $routePath,
                     'entity_class_name' => $entityClassDetails->getShortName(),
@@ -251,6 +367,33 @@ final class ApiCrud extends AbstractMaker
         );
     }
 
+
+    private function getPropertyNames(string $class): array
+    {
+        if (!class_exists($class)) {
+            return [];
+        }
+
+        $reflClass = new ReflectionClass($class);
+
+        return array_map(function (\ReflectionProperty $prop) {
+            return $prop->getName();
+        }, $reflClass->getProperties());
+    }
+
+    private function getPathOfClass(string $class): string
+    {
+        $classDetails = new ClassDetails($class);
+
+        return $classDetails->getPath();
+    }
+
+    private function writeWarning(string $message, ConsoleStyle $io)
+    {
+
+        $io->writeln('<fg=yellow;options=bold,underscore>[Warning] ' . $message . '</>');
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -272,11 +415,6 @@ final class ApiCrud extends AbstractMaker
         );
     }
 
-    /**
-     * @param array $associationMappings
-     *
-     * @return array
-     */
     private function getAssociations(array $associationMappings): array
     {
         $associations = [];
@@ -291,21 +429,16 @@ final class ApiCrud extends AbstractMaker
                 'target_entity' => $association['targetEntity'],
                 'target_entity_name' => $entityName,
                 'target_entity_type' => Str::asTwigVariable(Inflector::pluralize($entityName)),
-                'getter' => 'get'.Str::asCamelCase($association['fieldName']),
-                'setter' => 'set'.Str::asCamelCase($association['fieldName']),
-                'adder' => 'add'.Str::asCamelCase(Inflector::singularize($association['fieldName'])),
-                'remover' => 'remove'.Str::asCamelCase(Inflector::singularize($association['fieldName'])),
+                'getter' => 'get' . Str::asCamelCase($association['fieldName']),
+                'setter' => 'set' . Str::asCamelCase($association['fieldName']),
+                'adder' => 'add' . Str::asCamelCase(Inflector::singularize($association['fieldName'])),
+                'remover' => 'remove' . Str::asCamelCase(Inflector::singularize($association['fieldName'])),
             ];
         }
 
         return $associations;
     }
 
-    /**
-     * @param array $fieldMappings
-     *
-     * @return array
-     */
     private function getFields(array $fieldMappings): array
     {
         $fields = [];
@@ -317,8 +450,8 @@ final class ApiCrud extends AbstractMaker
                 'type' => $field['type'],
                 'unique' => $field['unique'] ?? false,
                 'nullable' => $field['nullable'] ?? false,
-                'getter' => 'get'.Str::asCamelCase($field['fieldName']),
-                'setter' => 'set'.Str::asCamelCase($field['fieldName']),
+                'getter' => 'get' . Str::asCamelCase($field['fieldName']),
+                'setter' => 'set' . Str::asCamelCase($field['fieldName']),
             ];
         }
 

--- a/src/Maker/EntityReaderService.php
+++ b/src/Maker/EntityReaderService.php
@@ -1,0 +1,127 @@
+<?php
+
+
+namespace Paknahad\JsonApiBundle\Maker;
+
+
+use Exception;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
+
+class EntityReaderService
+{
+    public const TO_MANY_RELATION = 'toMany';
+    public const TO_ONE_RELATION = 'toOne';
+    private const ENTITY_ID = 'id';
+
+    /**
+     * @param string $class
+     * @return array
+     * @throws Exception
+     */
+    public function getPropertyNames(string $class): array
+    {
+        $reflClass = $this->getReflectionClass($class);
+
+        $viableProperties = [];
+
+        foreach ($reflClass->getProperties() as $property) {
+            if ($this->isViableProperty($property) and $property->getName() !== self::ENTITY_ID) {
+                $viableProperties[] = $property->getName();
+            }
+        }
+        return $viableProperties;
+    }
+
+    /**
+     * @param string $class
+     * @return array
+     * @throws Exception
+     */
+    public function getRelations(string $class): array
+    {
+
+        $reflClass = $this->getReflectionClass($class);
+
+        $viableRelations = [];
+        foreach ($reflClass->getProperties() as $property) {
+            if ($this->isToOneRelation($property) and $property->getName() !== self::ENTITY_ID) {
+                $viableRelations[$property->getName()] = self::TO_ONE_RELATION;
+                continue;
+            }
+            if ($this->isToManyRelation($property) and $property->getName() !== self::ENTITY_ID) {
+                $viableRelations[$property->getName()] = self::TO_MANY_RELATION;
+            }
+        }
+        return $viableRelations;
+    }
+
+    /**
+     * @param string $classPath
+     * @return ReflectionClass
+     * @throws Exception
+     */
+    private function getReflectionClass(string $classPath): ReflectionClass
+    {
+        if (!class_exists($classPath)) {
+            throw new Exception(sprintf('Entity Class with class path %s does not exist!', $classPath));
+        }
+
+        try {
+            $reflClass = new ReflectionClass($classPath);
+        } catch (ReflectionException $e) {
+            throw new Exception('Could not read entity class. It probably has syntax errors.');
+        }
+        return $reflClass;
+    }
+
+    private function isToOneRelation(ReflectionProperty $property): bool
+    {
+        $doc = $property->getDocComment();
+        preg_match_all('#@(.*?)\n#s', $doc, $annotations);
+        $annotations = $annotations[1];
+
+        foreach ($annotations as $annotation) {
+            if ($this->matchAnnotation($annotation, 'ManyToOne') or $this->matchAnnotation($annotation, 'OneToOne')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function isToManyRelation(ReflectionProperty $property): bool
+    {
+        $doc = $property->getDocComment();
+        preg_match_all('#@(.*?)\n#s', $doc, $annotations);
+        $annotations = $annotations[1];
+
+        foreach ($annotations as $annotation) {
+            if ($this->matchAnnotation($annotation, 'OneToMany') or $this->matchAnnotation($annotation, 'ManyToMany')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    private function isViableProperty(ReflectionProperty $property): bool
+    {
+        $doc = $property->getDocComment();
+        preg_match_all('#@(.*?)\n#s', $doc, $annotations);
+        $annotations = $annotations[1];
+
+        foreach ($annotations as $annotation) {
+            if ($this->matchAnnotation($annotation, 'Column')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function matchAnnotation(string $annotation, string $expectedType): bool
+    {
+        return (bool)preg_match_all(sprintf('#ORM\\\%s\(.*?\)#s', $expectedType), $annotation);
+    }
+
+}

--- a/src/Maker/HydratorNodeVisitor.php
+++ b/src/Maker/HydratorNodeVisitor.php
@@ -11,6 +11,8 @@ class HydratorNodeVisitor extends NodeVisitorAbstract
 {
     private const METHOD_NAME = 'getAttributeHydrator';
     private const SETTER_PREFIX = 'set';
+    private const TYPE_ABSTRACT = 'abstract';
+    private const TYPE_CONCRETE = 'concrete';
     /**
      * @var String[]
      */
@@ -19,20 +21,73 @@ class HydratorNodeVisitor extends NodeVisitorAbstract
      * @var string
      */
     private $entityName;
-
     /**
-     * HydratorNodeVisitor constructor.
-     * @param String[] $propertyNames
-     * @param string $entityName
+     * @var string
      */
-    public function __construct(array $propertyNames, string $entityName)
+    private $relations;
+    /**
+     * @var string
+     */
+    private $hydratorType;
+
+    public function __construct(array $propertyNames, array $relations, string $entityName, string $hydratorType)
     {
         $this->propertyNames = $propertyNames;
         $this->entityName = $entityName;
+        $this->relations = $relations;
+        $this->hydratorType = $hydratorType;
     }
 
     public function leaveNode(Node $node)
     {
-        //TODO implment hydrator visitor
+        if ($node instanceof Node\Stmt\ClassMethod and $node->name->name === self::METHOD_NAME and $this->hydratorType !== self::TYPE_ABSTRACT) {
+            foreach ($node->stmts as $stmt) {
+                if ($stmt instanceof Node\Stmt\Return_) {
+                    $existingItems = $stmt->expr->items;
+                    $newItemNames = $this->filterExistingFields($existingItems, $this->propertyNames);
+
+                    foreach ($newItemNames as $newItemName) {
+                        $existingItems[] = $this->createNewAttributeItem($newItemName);
+                    }
+                    $stmt->expr->items = $existingItems;
+
+                }
+            }
+        }
+    }
+
+    private function createNewAttributeItem(string $newItem): Node\Expr\ArrayItem
+    {
+        $var = new Node\Expr\Variable(lcfirst($this->entityName));
+        $closureParam = new Node\Param($var, null, new Node\Name($this->entityName));
+        $functionName = self::SETTER_PREFIX . ucfirst($newItem);
+        $expr = new Node\Expr\MethodCall($var, $functionName, [new Node\Expr\Variable('attribute')]);
+        $setStmt = new Node\Stmt\Expression($expr);
+
+        $subNodes = [];
+        $subNodes['params'] = [$closureParam, new Node\Expr\Variable('attribute'), new Node\Expr\Variable('data'), new Node\Expr\Variable('attributeName')];
+        $subNodes['stmts'] = [$setStmt];
+
+        $closure = new Node\Expr\Closure($subNodes);
+        return new Node\Expr\ArrayItem($closure, new Node\Scalar\String_($newItem));
+    }
+
+    private function filterExistingFields(array $existingItems, array $entityItemNames): array
+    {
+        $existingItemNames = [];
+
+        foreach ($existingItems as $existingItem) {
+            $existingItemNames[] = $existingItem->key->value;
+        }
+
+        $newItems = [];
+        foreach ($entityItemNames as $entityItemName) {
+
+            if (!in_array($entityItemName, $existingItemNames)) {
+                $newItems[] = $entityItemName;
+            }
+        }
+
+        return $newItems;
     }
 }

--- a/src/Maker/HydratorNodeVisitor.php
+++ b/src/Maker/HydratorNodeVisitor.php
@@ -4,12 +4,16 @@
 namespace Paknahad\JsonApiBundle\Maker;
 
 
+use Doctrine\Common\Inflector\Inflector;
 use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name;
 use PhpParser\NodeVisitorAbstract;
 
 class HydratorNodeVisitor extends NodeVisitorAbstract
 {
-    private const METHOD_NAME = 'getAttributeHydrator';
+    private const ATTRIBUTES_METHOD_NAME = 'getAttributeHydrator';
+    private const RELATIONSHIP_METHOD_NAME = 'getRelationshipHydrator';
     private const SETTER_PREFIX = 'set';
     private const TYPE_ABSTRACT = 'abstract';
     private const TYPE_CONCRETE = 'concrete';
@@ -21,26 +25,25 @@ class HydratorNodeVisitor extends NodeVisitorAbstract
      * @var string
      */
     private $entityName;
-    /**
-     * @var string
-     */
+
     private $relations;
     /**
      * @var string
      */
     private $hydratorType;
+    private $relationTypes;
 
     public function __construct(array $propertyNames, array $relations, string $entityName, string $hydratorType)
     {
         $this->propertyNames = $propertyNames;
         $this->entityName = $entityName;
-        $this->relations = $relations;
+        [$this->relations, $this->relationTypes] = $this->unpackRelations($relations);
         $this->hydratorType = $hydratorType;
     }
 
     public function leaveNode(Node $node)
     {
-        if ($node instanceof Node\Stmt\ClassMethod and $node->name->name === self::METHOD_NAME and $this->hydratorType !== self::TYPE_ABSTRACT) {
+        if ($node instanceof Node\Stmt\ClassMethod and $node->name->name === self::ATTRIBUTES_METHOD_NAME and $this->hydratorType !== self::TYPE_ABSTRACT) {
             foreach ($node->stmts as $stmt) {
                 if ($stmt instanceof Node\Stmt\Return_) {
                     $existingItems = $stmt->expr->items;
@@ -48,6 +51,20 @@ class HydratorNodeVisitor extends NodeVisitorAbstract
 
                     foreach ($newItemNames as $newItemName) {
                         $existingItems[] = $this->createNewAttributeItem($newItemName);
+                    }
+                    $stmt->expr->items = $existingItems;
+
+                }
+            }
+        }
+        if ($node instanceof Node\Stmt\ClassMethod and $node->name->name === self::RELATIONSHIP_METHOD_NAME and $this->hydratorType === self::TYPE_ABSTRACT) {
+            foreach ($node->stmts as $stmt) {
+                if ($stmt instanceof Node\Stmt\Return_) {
+                    $existingItems = $stmt->expr->items;
+                    $newItemNames = $this->filterExistingFields($existingItems, $this->relations);
+
+                    foreach ($newItemNames as $newItemName) {
+                        $existingItems[] = $this->createNewRelationItem($newItemName, $this->relationTypes[$newItemName]);
                     }
                     $stmt->expr->items = $existingItems;
 
@@ -72,6 +89,46 @@ class HydratorNodeVisitor extends NodeVisitorAbstract
         return new Node\Expr\ArrayItem($closure, new Node\Scalar\String_($newItem));
     }
 
+    private function createNewRelationItem(string $relationName, string $relationType): Node\Expr\ArrayItem
+    {
+        $entityVar = new Node\Expr\Variable(lcfirst($this->entityName));
+        $relationshipNameVar = new Node\Expr\Variable('relationshipName');
+        $relationVar = new Node\Expr\Variable(lcfirst($relationName));
+        $identifier = new Node\Expr\Variable('identifier');
+        $association = new Node\Expr\Variable('association');
+        $thisVar = new Node\Expr\Variable('this');
+        $nullValue = new ConstFetch(new Name('null'));
+
+        $entityParam = new Node\Param($entityVar, null, new Node\Name($this->entityName));
+        $relationshipTypeParam = new Node\Param($relationVar, null, 'ToOneRelationship'); //TODO
+        $stmts = [];
+        $validate = new Node\Expr\MethodCall($thisVar, 'validateRelationType', [$relationVar, new Node\Expr\Array_([new Node\Scalar\String_(Inflector::pluralize($relationName))], [Node\Expr\Array_::KIND_SHORT])]);
+        $assocNull = new Node\Expr\Assign($association, $nullValue);
+        $identifierStmt = new Node\Expr\Assign($identifier, new Node\Expr\MethodCall($relationVar, 'getResourceIdentifier'));
+
+        $findMethod = new Node\Expr\MethodCall(new Node\Expr\MethodCall(new Node\Expr\PropertyFetch($thisVar, 'objectManager'), 'getRepository', [new Node\Scalar\String_('App\\Entity\\' . ucfirst($relationName))]), 'find', [new Node\Expr\MethodCall($identifier, 'getId')]);
+
+        $assocRepo = new Node\Expr\Assign($association, $findMethod);
+
+        $ifIsNullSubNodes['stmts'] = [new Node\Stmt\Throw_(new Node\Expr\New_(new Name('InvalidRelationshipValueException'), [$relationshipNameVar, new Node\Expr\Array_([new Node\Expr\MethodCall($identifier, 'getId')], [Node\Expr\Array_::KIND_SHORT])]))];
+        $ifIsNull = new Node\Stmt\If_(new Node\Expr\FuncCall(new Node\Name('is_null'), [$association]), $ifIsNullSubNodes);
+
+        $ifSubNodes['stmts'] = [new Node\Stmt\Expression($assocRepo), $ifIsNull];
+
+        $ifStmt = new Node\Stmt\If_($identifier, $ifSubNodes);
+        $setStmt = new Node\Expr\MethodCall($entityVar, self::SETTER_PREFIX . ucfirst($relationName), [$association]);
+        $stmts[] = new Node\Stmt\Expression($validate);
+        $stmts[] = new Node\Stmt\Expression($assocNull);
+        $stmts[] = new Node\Stmt\Expression($identifierStmt);
+        $stmts[] = $ifStmt;
+        $stmts[] = new Node\Stmt\Expression($setStmt);
+        $subNodes = [];
+        $subNodes['params'] = [$entityParam, $relationshipTypeParam, new Node\Expr\Variable('data'), $relationshipNameVar];
+        $subNodes['stmts'] = $stmts;
+        $closure = new Node\Expr\Closure($subNodes);
+        return new Node\Expr\ArrayItem($closure, new Node\Scalar\String_($relationName));
+    }
+
     private function filterExistingFields(array $existingItems, array $entityItemNames): array
     {
         $existingItemNames = [];
@@ -89,5 +146,17 @@ class HydratorNodeVisitor extends NodeVisitorAbstract
         }
 
         return $newItems;
+    }
+
+    private function unpackRelations(array $relationsObject): array
+    {
+        $relations = [];
+        $relationsTypes = [];
+
+        foreach ($relationsObject as $relationName => $relationType) {
+            $relations[] = $relationName;
+            $relationsTypes[$relationName] = $relationType;
+        }
+        return [$relations, $relationsTypes];
     }
 }

--- a/src/Maker/HydratorNodeVisitor.php
+++ b/src/Maker/HydratorNodeVisitor.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Paknahad\JsonApiBundle\Maker;
+
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+class HydratorNodeVisitor extends NodeVisitorAbstract
+{
+    private const METHOD_NAME = 'getAttributeHydrator';
+    private const SETTER_PREFIX = 'set';
+    /**
+     * @var String[]
+     */
+    private $propertyNames;
+    /**
+     * @var string
+     */
+    private $entityName;
+
+    /**
+     * HydratorNodeVisitor constructor.
+     * @param String[] $propertyNames
+     * @param string $entityName
+     */
+    public function __construct(array $propertyNames, string $entityName)
+    {
+        $this->propertyNames = $propertyNames;
+        $this->entityName = $entityName;
+    }
+
+    public function leaveNode(Node $node)
+    {
+        //TODO implment hydrator visitor
+    }
+}

--- a/src/Maker/NodeFactory.php
+++ b/src/Maker/NodeFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace Paknahad\JsonApiBundle\Maker;
+
+use PhpParser\Node;
+
+class NodeFactory
+{
+
+    public function makeString($value): Node\Scalar\String_ {
+        return new Node\Scalar\String_($value);
+    }
+
+
+    public function createNewItem($className, $propertyName): Node\Expr\ArrayItem
+    {
+
+        $key = new Node\Scalar\String_($className);
+        $value = new Node\Expr\Closure();
+        $closureParam =
+        $type = new Node\Name('Product');
+        $functionName = 'get'.ucfirst($className);
+
+        $newAttribute = new Node\Expr\ArrayItem();
+    }
+
+}

--- a/src/Maker/NodeFactory.php
+++ b/src/Maker/NodeFactory.php
@@ -3,26 +3,31 @@
 
 namespace Paknahad\JsonApiBundle\Maker;
 
-use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
 
 class NodeFactory
 {
 
-    public function makeString($value): Node\Scalar\String_ {
-        return new Node\Scalar\String_($value);
-    }
-
-
-    public function createNewItem($className, $propertyName): Node\Expr\ArrayItem
+    /**
+     * @param String[] $propertyNames
+     * @param string $entityName
+     * @return NodeVisitorAbstract
+     */
+    public function makeTransformerVisitor(array $propertyNames, string $entityName): NodeVisitorAbstract
     {
 
-        $key = new Node\Scalar\String_($className);
-        $value = new Node\Expr\Closure();
-        $closureParam =
-        $type = new Node\Name('Product');
-        $functionName = 'get'.ucfirst($className);
+        return new TransformerNodeVisitor($propertyNames, $entityName);
 
-        $newAttribute = new Node\Expr\ArrayItem();
     }
+    /**
+     * @param String[] $propertyNames
+     * @param string $entityName
+     * @return NodeVisitorAbstract
+     */
+    public function makeHydratorVisitor(array $propertyNames, string $entityName): NodeVisitorAbstract
+    {
+        return new HydratorNodeVisitor($propertyNames, $entityName);
+    }
+
 
 }

--- a/src/Maker/NodeVisitorFactory.php
+++ b/src/Maker/NodeVisitorFactory.php
@@ -5,20 +5,22 @@ namespace Paknahad\JsonApiBundle\Maker;
 
 use PhpParser\NodeVisitorAbstract;
 
-class NodeFactory
+class NodeVisitorFactory
 {
 
     /**
      * @param String[] $propertyNames
+     * @param array $relations
      * @param string $entityName
      * @return NodeVisitorAbstract
      */
-    public function makeTransformerVisitor(array $propertyNames, string $entityName): NodeVisitorAbstract
+    public function makeTransformerVisitor(array $propertyNames, array $relations, string $entityName): NodeVisitorAbstract
     {
 
-        return new TransformerNodeVisitor($propertyNames, $entityName);
+        return new TransformerNodeVisitor($propertyNames, $relations, $entityName);
 
     }
+
     /**
      * @param String[] $propertyNames
      * @param string $entityName

--- a/src/Maker/NodeVisitorFactory.php
+++ b/src/Maker/NodeVisitorFactory.php
@@ -23,12 +23,14 @@ class NodeVisitorFactory
 
     /**
      * @param String[] $propertyNames
+     * @param array $relations
      * @param string $entityName
+     * @param string $hydratorType
      * @return NodeVisitorAbstract
      */
-    public function makeHydratorVisitor(array $propertyNames, string $entityName): NodeVisitorAbstract
+    public function makeHydratorVisitor(array $propertyNames, array $relations, string $entityName, string $hydratorType): NodeVisitorAbstract
     {
-        return new HydratorNodeVisitor($propertyNames, $entityName);
+        return new HydratorNodeVisitor($propertyNames, $relations, $entityName, $hydratorType);
     }
 
 

--- a/src/Maker/TransformerNodeVisitor.php
+++ b/src/Maker/TransformerNodeVisitor.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace Paknahad\JsonApiBundle\Maker;
+
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+class TransformerNodeVisitor extends NodeVisitorAbstract
+{
+    private const METHOD_NAME = 'getAttributes';
+    private const GETTER_PREFIX = 'get';
+    private $className;
+    private $propertyNames;
+
+    public function __construct($propertyNames, $className)
+    {
+        $this->propertyNames = $propertyNames;
+        $this->className = $className;
+    }
+
+    public function leaveNode(Node $node)
+    {
+        if ($node instanceof Node\Stmt\ClassMethod and $node->name->name === self::METHOD_NAME) {
+            foreach ($node->stmts as $stmt) {
+                if ($stmt instanceof Node\Stmt\Return_) {
+                    $existingItems = $stmt->expr->items;
+                    $existingItemNames = $stmt->expr->items;
+                    $newItems = [];
+
+                    foreach ($existingItems as $existingItem) {
+                        $existingItemNames[] = $existingItem->key->value;
+                    }
+
+                    foreach ($this->propertyNames as $propertyName) {
+
+                        if (!in_array($propertyName, $existingItemNames)) {
+                            $newItems[] = $propertyName;
+                        }
+                    }
+                    foreach ($newItems as $newItem) {
+                        $newAttribute = $this->createNewItem($newItem);
+                        $existingItems[] = $newAttribute;
+                    }
+                    $stmt->expr->items = $existingItems;
+
+
+                }
+            }
+        }
+    }
+
+    private function createNewItem(string $newItem): Node\Expr\ArrayItem
+    {
+        $key = new Node\Scalar\String_($newItem);
+        $type = new Node\Name($this->className);
+        $var = new Node\Expr\Variable(lcfirst($this->className));
+        $closureParam = new Node\Param($var, null, $type);
+        $functionName = self::GETTER_PREFIX . ucfirst($newItem);
+        $expr = new Node\Expr\MethodCall($var, $functionName);
+        $return = new Node\Stmt\Return_($expr);
+
+        $subNodes = [];
+        $subNodes['params'] = [$closureParam];
+        $subNodes['stmts'] = [$return];
+
+        $closure = new Node\Expr\Closure($subNodes);
+        return new Node\Expr\ArrayItem($closure, $key);
+    }
+}

--- a/src/Maker/TransformerNodeVisitor.php
+++ b/src/Maker/TransformerNodeVisitor.php
@@ -61,7 +61,15 @@ class TransformerNodeVisitor extends NodeVisitorAbstract
     public function afterTraverse(array $nodes)
     {
         $existingUses = [];
-        foreach ($nodes[0]->stmts as $stmt) {
+        $namespace = null;
+        foreach ($nodes as $node){
+            if($node instanceof Node\Stmt\Namespace_){
+                $namespace = $node;
+            }
+        }
+
+
+        foreach ($namespace->stmts as $stmt) {
             if ($stmt instanceof Node\Stmt\Use_) {
                 $existingUses[] = $this->parseUseStatement($stmt);
             }
@@ -69,7 +77,7 @@ class TransformerNodeVisitor extends NodeVisitorAbstract
 
         foreach ($this->newUseClasses as $newUseClass) {
             if (!in_array($newUseClass, $existingUses)) {
-                array_unshift($nodes[0]->stmts, $this->createNewUseClass($newUseClass));
+                array_unshift($namespace->stmts, $this->createNewUseClass($newUseClass));
             }
         }
 

--- a/src/Maker/TransformerNodeVisitor.php
+++ b/src/Maker/TransformerNodeVisitor.php
@@ -4,44 +4,51 @@
 namespace Paknahad\JsonApiBundle\Maker;
 
 
+use Exception;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 class TransformerNodeVisitor extends NodeVisitorAbstract
 {
-    private const METHOD_NAME = 'getAttributes';
+    private const GET_ATTRIBUTES = 'getAttributes';
+    private const GET_RELATIONSHIPS = 'getRelationships';
     private const GETTER_PREFIX = 'get';
     private $className;
     private $propertyNames;
+    private $relations;
+    private $relationTypes;
+    private $newUseClasses = [];
 
-    public function __construct($propertyNames, $className)
+    public function __construct($propertyNames, $relations, $className)
     {
         $this->propertyNames = $propertyNames;
         $this->className = $className;
+        [$this->relations, $this->relationTypes] = $this->unpackRelations($relations);
     }
 
     public function leaveNode(Node $node)
     {
-        if ($node instanceof Node\Stmt\ClassMethod and $node->name->name === self::METHOD_NAME) {
+        if ($node instanceof Node\Stmt\ClassMethod and $node->name->name === self::GET_ATTRIBUTES) {
             foreach ($node->stmts as $stmt) {
                 if ($stmt instanceof Node\Stmt\Return_) {
                     $existingItems = $stmt->expr->items;
-                    $existingItemNames = $stmt->expr->items;
-                    $newItems = [];
+                    $newItemNames = $this->filterExistingFields($existingItems, $this->propertyNames);
 
-                    foreach ($existingItems as $existingItem) {
-                        $existingItemNames[] = $existingItem->key->value;
+                    foreach ($newItemNames as $newItemName) {
+                        $existingItems[] = $this->createNewAttributeItem($newItemName);
                     }
+                    $stmt->expr->items = $existingItems;
 
-                    foreach ($this->propertyNames as $propertyName) {
+                }
+            }
+        } else if ($node instanceof Node\Stmt\ClassMethod and $node->name->name === self::GET_RELATIONSHIPS) {
+            foreach ($node->stmts as $stmt) {
+                if ($stmt instanceof Node\Stmt\Return_) {
+                    $existingItems = $stmt->expr->items;
+                    $newItemNames = $this->filterExistingFields($existingItems, $this->relations);
 
-                        if (!in_array($propertyName, $existingItemNames)) {
-                            $newItems[] = $propertyName;
-                        }
-                    }
-                    foreach ($newItems as $newItem) {
-                        $newAttribute = $this->createNewItem($newItem);
-                        $existingItems[] = $newAttribute;
+                    foreach ($newItemNames as $newItemName) {
+                        $existingItems[] = $this->createNewRelationItem($newItemName, $this->relationTypes[$newItemName]);
                     }
                     $stmt->expr->items = $existingItems;
 
@@ -51,7 +58,43 @@ class TransformerNodeVisitor extends NodeVisitorAbstract
         }
     }
 
-    private function createNewItem(string $newItem): Node\Expr\ArrayItem
+    public function afterTraverse(array $nodes)
+    {
+        $existingUses = [];
+        foreach ($nodes[0]->stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\Use_) {
+                $existingUses[] = $this->parseUseStatement($stmt);
+            }
+        }
+
+        foreach ($this->newUseClasses as $newUseClass) {
+            if (!in_array($newUseClass, $existingUses)) {
+                array_unshift($nodes[0]->stmts, $this->createNewUseClass($newUseClass));
+            }
+        }
+
+    }
+
+    private function filterExistingFields(array $existingItems, array $entityItemNames): array
+    {
+        $existingItemNames = [];
+
+        foreach ($existingItems as $existingItem) {
+            $existingItemNames[] = $existingItem->key->value;
+        }
+
+        $newItems = [];
+        foreach ($entityItemNames as $entityItemName) {
+
+            if (!in_array($entityItemName, $existingItemNames)) {
+                $newItems[] = $entityItemName;
+            }
+        }
+
+        return $newItems;
+    }
+
+    private function createNewAttributeItem(string $newItem): Node\Expr\ArrayItem
     {
         $key = new Node\Scalar\String_($newItem);
         $type = new Node\Name($this->className);
@@ -67,5 +110,75 @@ class TransformerNodeVisitor extends NodeVisitorAbstract
 
         $closure = new Node\Expr\Closure($subNodes);
         return new Node\Expr\ArrayItem($closure, $key);
+    }
+
+    private function createNewRelationItem(string $newItem, string $relationType): Node\Expr\ArrayItem
+    {
+        $type = new Node\Name($this->className);
+        $var = new Node\Expr\Variable(lcfirst($this->className));
+        $closureParam = new Node\Param($var, null, $type);
+
+        $relationClassName = $this->buildRelationType($newItem, $relationType);
+
+        $expr = new Node\Expr\StaticCall($relationClassName, 'create');
+        $functionName = self::GETTER_PREFIX . ucfirst($newItem);
+        $returnClosureExpr = new Node\Expr\MethodCall($var, $functionName);
+        $returnClosure = new Node\Stmt\Return_($returnClosureExpr);
+        $closureUse = new Node\Param($var);
+        $subNodes = [];
+        $subNodes['uses'] = [$closureUse];
+        $subNodes['stmts'] = [$returnClosure];
+        $closure = new Node\Expr\Closure($subNodes);
+        $relationTransformerName = new Node\Name (ucfirst($newItem) . 'ResourceTransformer');
+        $relationTransformerNew = new Node\Expr\New_($relationTransformerName);
+        $methodCall = new Node\Expr\MethodCall($expr, 'setDataAsCallable', [$closure, $relationTransformerNew]);
+        $methodCall2 = new Node\Expr\MethodCall($methodCall, 'omitDataWhenNotIncluded');
+
+        $return = new Node\Stmt\Return_($methodCall2);
+        $key = new Node\Scalar\String_($newItem);
+        $subNodes = [];
+        $subNodes['params'] = [$closureParam];
+        $subNodes['stmts'] = [$return];
+        $closure = new Node\Expr\Closure($subNodes);
+        return new Node\Expr\ArrayItem($closure, $key);
+    }
+
+    private function unpackRelations(array $relationsObject): array
+    {
+        $relations = [];
+        $relationsTypes = [];
+
+        foreach ($relationsObject as $relationName => $relationType) {
+            $relations[] = $relationName;
+            $relationsTypes[$relationName] = $relationType;
+        }
+        return [$relations, $relationsTypes];
+    }
+
+    private function buildRelationType(string $newItem, string $relationType): Node\Name
+    {
+
+        if ($relationType === EntityReaderService::TO_MANY_RELATION) {
+            $this->newUseClasses[] = 'ToManyRelationship';
+            return new Node\Name('ToManyRelationship');
+        }
+        if ($relationType === EntityReaderService::TO_ONE_RELATION) {
+            $this->newUseClasses[] = 'ToOneRelationship';
+            return new Node\Name('ToOneRelationship');
+        }
+        throw new Exception(sprintf('Could not determine relation type of %s', $newItem));
+    }
+
+    private function parseUseStatement(Node\Stmt\Use_ $stmt): string
+    {
+        return end($stmt->uses[0]->name->parts);
+    }
+
+    private function createNewUseClass(string $newUseClass): Node\Stmt\Use_
+    {
+        $parts = ['WoohooLabs', 'Yin', 'JsonApi', 'Schema', 'Relationship', $newUseClass];
+        $name = new Node\Name($parts);
+        $uses = [new Node\Stmt\UseUse($name)];
+        return new Node\Stmt\Use_($uses);
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -32,10 +32,18 @@
             <argument>%kernel.project_dir%</argument>
         </service>
 
+        <service id="jsonapi.open_api_collection_generator" class="Paknahad\JsonApiBundle\Collection\OpenApiCollectionGenerator">
+            <argument type="service" id="maker.file_manager" />
+            <argument>%kernel.project_dir%</argument>
+        </service>
+
         <service id="maker.maker.make_api" class="Paknahad\JsonApiBundle\Maker\ApiCrud">
             <tag name="maker.command" />
+            <argument/>
+            <argument/>
             <argument type="service" id="jsonapi.postman_collection_generator" />
             <argument type="service" id="jsonapi.swagger_collection_generator" />
+            <argument type="service" id="jsonapi.open_api_collection_generator" />
             <argument type="service" id="maker.doctrine_helper" />
             <argument type="service" id="maker.file_manager" />
         </service>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -37,6 +37,7 @@
             <argument type="service" id="jsonapi.postman_collection_generator" />
             <argument type="service" id="jsonapi.swagger_collection_generator" />
             <argument type="service" id="maker.doctrine_helper" />
+            <argument type="service" id="maker.file_manager" />
         </service>
 
         <service class="Paknahad\JsonApiBundle\Helper\Filter\Finder" id="paknahad_json_api.helper_filter.finder">
@@ -51,6 +52,7 @@
         <service id="Paknahad\JsonApiBundle\Helper\Paginator" />
 
         <service id="Paknahad\JsonApiBundle\Helper\Sorter" />
+        <service id="Paknahad\JsonApiBundle\Maker\NodeFactory" />
         <service id="Paknahad\JsonApiBundle\Helper\FieldManager" />
         <service id="WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory" />
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -60,7 +60,8 @@
         <service id="Paknahad\JsonApiBundle\Helper\Paginator" />
 
         <service id="Paknahad\JsonApiBundle\Helper\Sorter" />
-        <service id="Paknahad\JsonApiBundle\Maker\NodeFactory" />
+        <service id="Paknahad\JsonApiBundle\Maker\NodeVisitorFactory" />
+        <service id="Paknahad\JsonApiBundle\Maker\EntityReaderService" />
         <service id="Paknahad\JsonApiBundle\Helper\FieldManager" />
         <service id="WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory" />
 

--- a/src/Resources/skeleton/api/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/api/controller/Controller.tpl.php
@@ -11,10 +11,9 @@ use <?= $transformer_full_class_name ?>;
 use <?= $repository_full_class_name ?>;
 use Paknahad\JsonApiBundle\Controller\Controller;
 use Paknahad\JsonApiBundle\Helper\ResourceCollection;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Validator\ConstraintViolationList;
-use Symfony\Component\Routing\Annotation\Route;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory;
 
@@ -24,7 +23,7 @@ use WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory;
 class <?= $class_name ?> extends Controller
 {
     /**
-     * @Route("/", name="<?= $route_name ?>_index", methods="GET")
+     * @Route("", name="<?= $route_name ?>_index", methods="GET")
      */
     public function index(<?= $repository_class_name ?> $<?= $repository_var ?>, ResourceCollection $resourceCollection): ResponseInterface
     {
@@ -39,7 +38,7 @@ class <?= $class_name ?> extends Controller
     }
 
     /**
-     * @Route("/", name="<?= $route_name ?>_new", methods="POST")
+     * @Route("", name="<?= $route_name ?>_new", methods="POST")
      */
     public function new(ValidatorInterface $validator, DefaultExceptionFactory $exceptionFactory): ResponseInterface
     {
@@ -102,7 +101,7 @@ class <?= $class_name ?> extends Controller
     /**
      * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_delete", methods="DELETE")
      */
-    public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_name ?>): ResponseInterface
+    public function delete(<?= $entity_class_name ?> $<?= $entity_var_name ?>): ResponseInterface
     {
         $entityManager = $this->getDoctrine()->getManager();
         $entityManager->remove($<?= $entity_var_name?>);

--- a/src/Resources/skeleton/open_api.yaml
+++ b/src/Resources/skeleton/open_api.yaml
@@ -1,23 +1,23 @@
-swagger: "2.0"
+openapi: 3.0.0
 info:
-  description: ""
+  description: "This is where you can give more detailed description of your API"
   version: "1.0.0"
-  title: "Swagger JsonApi"
+  title: "Openapi JsonApi"
   termsOfService: "http://swagger.io/terms/"
   license:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-host: "localhost"
-schemes:
-- "https"
-- "http"
 paths:
-securityDefinitions:
-  api_key:
-    type: "apiKey"
-    name: "api_key"
-    in: "header"
-definitions:
 externalDocs:
   description: "Find out more about Swagger"
   url: "http://swagger.io"
+servers:
+  - url: http://localhost:8000/api
+    description: Local Environment
+components:
+  securitySchemes:
+    bearerToken:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:

--- a/src/Resources/skeleton/open_api.yaml
+++ b/src/Resources/skeleton/open_api.yaml
@@ -1,0 +1,23 @@
+swagger: "2.0"
+info:
+  description: ""
+  version: "1.0.0"
+  title: "Swagger JsonApi"
+  termsOfService: "http://swagger.io/terms/"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "localhost"
+schemes:
+- "https"
+- "http"
+paths:
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "api_key"
+    in: "header"
+definitions:
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io"


### PR DESCRIPTION
Hi,

first of all, I would like to thank you for your work. We have been using your bundle for a while now and it has proven very useful to us.

I have noticed that generating transformer classes once can cause problem in agile development where there are constant changes on entity classes. Adding a new field to a single entity also requires adding it to both hydrator and transformer classes as well as documentation and postman collection. This PR aims to add update functionality so that make:api command can be used in the same way as make:entity. The main idea is that you don't have to propagate changes on multiple locations. This is achieved using PhpParser module and adding new attributes and relations. Also, since the new OpenApi specification is out, this PR includes the new documentation format.

This PR does not break original functionality, and does not add additional dependencies since all of these are already required by the maker bundle. 

Since the projects I work on are using symfony 4.4, I have lowered original requirements from 4.0.0 version of this bundle. This means that this PR is intented as 3.1.0 version, if you decide to approve it. The added features are fairly large, so I understand if you would like to keep your codebase clean and reject this PR.


Changelist:

1. Removed unused parameter $request from DELETE call.
2. Removed trailing slashes on routes both in Controller and documentation.
3. Added configuration for changing default Controller namespace. (ex. if you use "Controller/Api")
4. Added new documentation schema based on OpenAPI 3.0.0 specification. You can chose documentation format with configuration.
5. Added update functionality on make:api command. It will now update fields in Transformer and Hydrator if there are new fields in Entity. It will also ignore files that don't have dependencies on attributes (Document, Controller).
6. Added check for postman collection. If an item already exists, it will be replaced instead of duplicated. This also ensures update of fields in the postman collection.
7. Added seed for random so it does not update documentation unnecessarily with random values. Also, resources are sorted alphabetically after each run.


TODO and future work:

1. Add annotations for excluding entity properties from Transformer or Hydrator. Annotations only affect make:api command and have no impact on application runtime.
2. Add support for different relation name. (if RelationPropertyName != RelationClassName).
3. Add --clean option that removes existing fields from transformer and hydrator classes that are not found in entity.
4. Add configurable option for trailing slashes (yes or no).



To test this, you should be able to run make:api multiple times on a single entity, after adding properties or relations. They should be added to the hydrator and transformer after running make:api.

There is still some work to do, but I would like to hear your opinion on these changes.