### PR TITLE
add openapi documentation schema with configuration

### DIFF
--- a/src/Collection/CollectionGeneratorAbstract.php
+++ b/src/Collection/CollectionGeneratorAbstract.php
@@ -41,4 +41,9 @@ abstract class CollectionGeneratorAbstract
 
         return $actions;
     }
+
+    public function setSeed(int $int)
+    {
+        srand($int);
+    }
 }

--- a/src/Collection/OpenApi/Attributes.php
+++ b/src/Collection/OpenApi/Attributes.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\Attribute;
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\Relation;
+use phootwork\collection\Map;
+
+class Attributes
+{
+    /** @var Map */
+    private $fields;
+
+    /** @var Map */
+    private $relations;
+
+    private function __construct()
+    {
+        $this->fields = new Map();
+        $this->relations = new Map();
+    }
+
+    public static function parse(ClassMetadataInfo $classMetadata): self
+    {
+        $attributes = new self();
+
+        foreach ($classMetadata->fieldMappings as $field) {
+            $attributes->addField(new Attribute($field));
+        }
+
+        foreach ($classMetadata->associationMappings as $relation) {
+            $attributes->addRelation(new Relation($relation));
+        }
+
+        return $attributes;
+    }
+
+    private function addField(Attribute $field): void
+    {
+        $this->fields->set($field->get('fieldName'), $field);
+    }
+
+    private function addRelation(Relation $relation): void
+    {
+        $this->relations->set($relation->get('fieldName'), $relation);
+    }
+
+    public function getFieldsSchema()
+    {
+        $result = [];
+        $this->fields->each(function (string $key, Attribute $field) use (&$result) {
+            if (!$field->isPrimaryKey()) {
+                $result = array_merge($result, $field->toArray());
+            }
+        });
+
+        return [
+            'type' => 'object',
+            'properties' => $result,
+        ];
+    }
+
+    public function getRelationsSchemas()
+    {
+        $result = [];
+        $this->relations->each(function (string $key, Relation $relation) use (&$result) {
+            $result[$relation->generateName()] = [
+                'type' => 'object',
+                'properties' => $relation->toArray(),
+            ];
+        });
+
+        return $result;
+    }
+
+    public function getRelations()
+    {
+        $result = [];
+        $this->relations->each(function (string $key, Relation $relation) use (&$result) {
+            $result = array_merge($result, $relation->getDefinitionPath());
+        });
+
+        return ['properties' => $result];
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Attribute.php
+++ b/src/Collection/OpenApi/JsonApi/Attribute.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+class Attribute extends AttributeAbstract
+{
+    public function isPrimaryKey(): bool
+    {
+        return $this->metadata->has('id') && (bool) ($this->get('id'));
+    }
+
+    public function toArray()
+    {
+        $array = [$this->get('fieldName') => $this->getSwaggerType()];
+
+        return $array;
+    }
+
+    private function getSwaggerType()
+    {
+        switch ($this->get('type')) {
+            case 'json':
+                return [
+                    'type' => 'object',
+                ];
+
+            case 'float':
+            case 'decimal':
+                return [
+                    'type' => 'number',
+                    'format' => $this->get('type'),
+                ];
+
+            case 'smallint':
+            case 'bigint':
+            case 'integer':
+                return [
+                    'type' => 'integer',
+                    'format' => ('bigint' === $this->get('type')) ? 'int64' : 'int32',
+                ];
+
+            case 'date':
+            case 'date_immutable':
+                return [
+                    'type' => 'string',
+                    'format' => 'date',
+                ];
+
+            case 'datetime':
+            case 'datetime_immutable':
+            case 'datetimetz':
+            case 'datetimetz_immutable':
+                return [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                ];
+
+            default:
+                return [
+                    'type' => $this->get('type'),
+                ];
+        }
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/AttributeAbstract.php
+++ b/src/Collection/OpenApi/JsonApi/AttributeAbstract.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use phootwork\collection\CollectionUtils;
+
+abstract class AttributeAbstract
+{
+    protected $metadata;
+
+    public function __construct(array $metadata)
+    {
+        $this->metadata = CollectionUtils::toMap($metadata);
+    }
+
+    public function get(string $name)
+    {
+        return $this->metadata->get($name);
+    }
+
+    abstract public function toArray();
+}

--- a/src/Collection/OpenApi/JsonApi/DataAbstract.php
+++ b/src/Collection/OpenApi/JsonApi/DataAbstract.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\OpenApi\Attributes;
+use Paknahad\JsonApiBundle\JsonApiStr;
+
+abstract class DataAbstract
+{
+    /** @var Attributes */
+    private $attributes;
+
+    protected $entityName;
+    protected $actionName;
+    protected $route;
+
+    public function __construct(string $entityName, Attributes $attributes, string $actionName, string $route)
+    {
+        $this->entityName = $entityName;
+        $this->actionName = $actionName;
+        $this->attributes = $attributes;
+        $this->route = $route;
+    }
+
+    abstract public function toArray(): array;
+
+    protected function genJsonApiDataBody(bool $containId = false): array
+    {
+        if ($containId) {
+            $idProperties = [
+                'id' => [
+                    'type' => 'integer',
+                    'format' => 'int64',
+                    'example' => 12,
+                ],
+            ];
+        } else {
+            $idProperties = [];
+        }
+
+        return [
+            'type' => 'object',
+            'properties' => array_merge(
+                $idProperties,
+                [
+                    'type' => ['type' => 'string', 'example' => JsonApiStr::entityNameToType($this->entityName)],
+                    'attributes' => ['$ref' => '#/components/schemas/'.$this->entityName],
+                    'relationships' => $this->attributes->getRelations(),
+                ]
+            ),
+        ];
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Link.php
+++ b/src/Collection/OpenApi/JsonApi/Link.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\CollectionGeneratorAbstract;
+
+class Link
+{
+    public static function generateLinks(string $actionName, string $route): array
+    {
+        $links = [
+            'type' => 'object',
+            'properties' => [
+                'self' => ['type' => 'string', 'example' => $route],
+            ],
+        ];
+
+        if (CollectionGeneratorAbstract::LIST_ACTION === $actionName) {
+            $links['properties'] = [
+                'self' => ['type' => 'string', 'example' => $route.'?page[number]=1&page[size]=100'],
+                'first' => ['type' => 'string', 'example' => $route.'?page[number]=1&page[size]=100'],
+                'last' => ['type' => 'string', 'example' => $route.'?page[number]=1&page[size]=100'],
+                'prev' => ['type' => 'string', 'example' => 'null'],
+                'next' => ['type' => 'string', 'example' => 'null'],
+            ];
+        }
+
+        return $links;
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Parameters.php
+++ b/src/Collection/OpenApi/JsonApi/Parameters.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\CollectionGeneratorAbstract;
+use Paknahad\JsonApiBundle\JsonApiStr;
+
+class Parameters extends DataAbstract
+{
+    private function hasPathParam()
+    {
+        return \in_array(
+            $this->actionName,
+            [
+                CollectionGeneratorAbstract::VIEW_ACTION,
+                CollectionGeneratorAbstract::DELETE_ACTION,
+                CollectionGeneratorAbstract::EDIT_ACTION,
+            ]
+        );
+    }
+
+    private function getPathParams(): ?array
+    {
+        if (!$this->hasPathParam()) {
+            return null;
+        }
+
+        return [
+            'name' => JsonApiStr::genEntityIdName($this->entityName),
+            'in' => 'path',
+            'required' => true,
+            'schema' => ['type' => 'integer',
+                'format' => 'int64', ],
+        ];
+    }
+
+    public function toArray(): array
+    {
+        $params = [];
+
+        if ($param = $this->getPathParams()) {
+            $params[] = $param;
+        }
+
+        return $params;
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Relation.php
+++ b/src/Collection/OpenApi/JsonApi/Relation.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Paknahad\JsonApiBundle\JsonApiStr;
+
+class Relation extends AttributeAbstract
+{
+    const RELATIONS_SUFFIX = 'Relation';
+
+    public function toArray()
+    {
+        $array = [
+            'type' => [
+                'type' => 'string',
+                'enum' => [JsonApiStr::entityNameToType($this->get('targetEntity'))],
+                'example' => JsonApiStr::entityNameToType($this->get('targetEntity')),
+            ],
+            'id' => [
+                'type' => 'integer',
+                'minimum' => 1,
+                'description' => JsonApiStr::singularizeClassName($this->get('targetEntity')).' ID',
+                'example' => rand(2, 99),
+            ],
+        ];
+
+        return $array;
+    }
+
+    public function getDefinitionPath()
+    {
+        if (\in_array($this->get('type'), [ClassMetadataInfo::TO_MANY, ClassMetadataInfo::MANY_TO_MANY, ClassMetadataInfo::ONE_TO_MANY])) {
+            $relation = [
+                $this->get('fieldName') => [
+                    'type' => 'array',
+                    'items' => ['$ref' => '#/components/schemas/'.$this->generateName()],
+                ],
+            ];
+        } else {
+            $relation = [$this->get('fieldName') => ['$ref' => '#/components/schemas/'.$this->generateName()]];
+        }
+
+        return $relation;
+    }
+
+    public function generateName()
+    {
+        return JsonApiStr::singularizeClassName($this->get('targetEntity')).self::RELATIONS_SUFFIX;
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/RequestBody.php
+++ b/src/Collection/OpenApi/JsonApi/RequestBody.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\CollectionGeneratorAbstract;
+
+class RequestBody extends DataAbstract
+{
+    private function hasRequestBody()
+    {
+        return \in_array(
+            $this->actionName,
+            [
+                CollectionGeneratorAbstract::ADD_ACTION,
+                CollectionGeneratorAbstract::EDIT_ACTION,
+            ]
+        );
+    }
+
+    private function getRequestBody(): ?array
+    {
+        if (!$this->hasRequestBody()) {
+            return [];
+        }
+
+        return [
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'data' => $this->genJsonApiDataBody(true),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function toArray(): array
+    {
+        return $this->getRequestBody();
+    }
+}

--- a/src/Collection/OpenApi/JsonApi/Response.php
+++ b/src/Collection/OpenApi/JsonApi/Response.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi;
+
+use Paknahad\JsonApiBundle\Collection\CollectionGeneratorAbstract;
+
+class Response extends DataAbstract
+{
+    public function toArray(): array
+    {
+        $response = [
+            'jsonapi' => [
+                'type' => 'object',
+                'properties' => [
+                    'version' => ['type' => 'string', 'example' => '1.0'],
+                ],
+            ],
+            'links' => Link::generateLinks($this->actionName, $this->route),
+        ];
+
+        if (CollectionGeneratorAbstract::LIST_ACTION === $this->actionName) {
+            $response['data'] = [
+                'type' => 'array',
+                'items' => $this->genJsonApiDataBody(true),
+            ];
+        } else {
+            $response['data'] = $this->genJsonApiDataBody(true);
+        }
+
+        return [
+            'type' => 'object',
+            'properties' => $response,
+        ];
+    }
+}

--- a/src/Collection/OpenApi/OpenApi.php
+++ b/src/Collection/OpenApi/OpenApi.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi;
+
+use phootwork\collection\ArrayList;
+use phootwork\collection\CollectionUtils;
+use phootwork\collection\Map;
+use phootwork\lang\Arrayable;
+
+class OpenApi implements Arrayable
+{
+    private $content;
+    private $components = 'components';
+    private $schemas = 'schemas';
+
+    public function __construct(array $collection)
+    {
+        $this->content = CollectionUtils::toMap($collection);
+    }
+
+    public function addSchema(string $name, array $content): void
+    {
+        if (!$this->content->has($this->components)) {
+            $this->content->set($this->components, new Map());
+        }
+        $components = $this->content->get($this->components);
+        if (!$components->has($this->schemas)) {
+            $components->set($this->schemas, new Map());
+        }
+        /** @var Map $schema */
+        $schema = $components->get($this->schemas);
+
+        if (!$schema->has($name)) {
+            $schema->set($name, new Map());
+        }
+
+        $schema->remove($name);
+        $schema->set($name, $content);
+    }
+
+    public function addPath(string $name, array $content): void
+    {
+        $this->add('paths', $name, $content);
+    }
+
+    private function add(string $name, string $key, array $content): void
+    {
+        if (!$this->content->has($name)) {
+            $this->content->set($name, new Map());
+        }
+
+        $this->content->get($name)->remove($key);
+        $this->content->get($name)->set($key, $content);
+    }
+
+    public function toArray(): array
+    {
+        return self::mapToArray($this->content);
+    }
+
+    /**
+     * @param Map|ArrayList $collection
+     */
+    private function mapToArray($collection): array
+    {
+        $result = $collection->toArray();
+
+        foreach ($result as $key => &$content) {
+            if (\is_object($content)) {
+                $content = self::mapToArray($content);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Collection/OpenApi/Paths.php
+++ b/src/Collection/OpenApi/Paths.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection\OpenApi;
+
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\Parameters;
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\RequestBody;
+use Paknahad\JsonApiBundle\Collection\OpenApi\JsonApi\Response;
+use Paknahad\JsonApiBundle\JsonApiStr;
+
+class Paths
+{
+    public static function buildPaths(array $actions, string $entityName, string $route, Attributes $attributes): array
+    {
+        $paths = [];
+
+        foreach ($actions as $name => $action) {
+            $path = self::generateUrl($route, $name, $entityName);
+
+            $paths[$path][strtolower($action['method'])] = [
+                'tags' => [JsonApiStr::entityNameToType($entityName)],
+                'summary' => $action['title'],
+                'operationId' => $name.ucfirst($entityName),
+                'parameters' => (new Parameters($entityName, $attributes, $name, $route))->toArray(),
+                'requestBody' => (new RequestBody($entityName, $attributes, $name, $route))->toArray(),
+                'responses' => [
+                    '200' => [
+                        'description' => 'successful operation',
+                        'content' => [
+                            'application/json' => [
+                                'schema' => (new Response($entityName, $attributes, $name, $route))->toArray(),
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+            if (0 === \count($paths[$path][strtolower($action['method'])]['parameters'])) {
+                unset($paths[$path][strtolower($action['method'])]['parameters']);
+            }
+            if (0 === \count($paths[$path][strtolower($action['method'])]['requestBody'])) {
+                unset($paths[$path][strtolower($action['method'])]['requestBody']);
+            }
+        }
+
+        return $paths;
+    }
+
+    private static function generateUrl($baseRoute, $actionName, $entityName)
+    {
+        return $baseRoute.
+            (
+            \in_array($actionName, ['edit', 'delete', 'view']) ?
+                '/'.JsonApiStr::genEntityIdName($entityName, true) : ''
+            );
+    }
+}

--- a/src/Collection/OpenApiCollectionGenerator.php
+++ b/src/Collection/OpenApiCollectionGenerator.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Collection;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Paknahad\JsonApiBundle\Collection\OpenApi\Attributes;
+use Paknahad\JsonApiBundle\Collection\OpenApi\OpenApi;
+use Paknahad\JsonApiBundle\Collection\OpenApi\Paths;
+use Symfony\Component\Yaml\Yaml;
+
+class OpenApiCollectionGenerator extends CollectionGeneratorAbstract
+{
+    /** @var OpenApi */
+    private $openApi;
+    /** @var Attributes */
+    private $fields;
+
+    const OPEN_API_PATH = 'collections/open_api.yaml';
+    const OPEN_API_TEMPLATE_PATH = __DIR__.'/../Resources/skeleton/open_api.yaml';
+
+    public function generateCollection(ClassMetadataInfo $classMetadata, string $entityName, string $route): string
+    {
+        $this->setSeed(12345678);
+
+        $this->openApi = new OpenApi($this->loadOldCollection());
+
+        $this->fields = Attributes::parse($classMetadata);
+
+        $this->setSchemas($entityName);
+        $this->generateAllPaths($entityName, $route);
+
+        $arrayFile = $this->openApi->toArray();
+
+        ksort($arrayFile['paths']);
+        ksort($arrayFile['components']['schemas']);
+
+        $this->fileManager->dumpFile(self::OPEN_API_PATH, Yaml::dump($arrayFile, 20, 2));
+
+        return self::OPEN_API_PATH;
+    }
+
+    private function generateAllPaths(string $entityName, string $route): void
+    {
+        $paths = Paths::buildPaths($this->getActionsList($entityName), $entityName, $route, $this->fields);
+
+        foreach ($paths as $path => $content) {
+            $this->openApi->addPath($path, $content);
+        }
+    }
+
+    private function setSchemas(string $entityName): void
+    {
+        $this->openApi->addSchema($entityName, $this->fields->getFieldsSchema());
+
+        foreach ($this->fields->getRelationsSchemas() as $name => $schema) {
+            $this->openApi->addSchema($name, $schema);
+        }
+    }
+
+    private function loadOldCollection(): array
+    {
+        if (file_exists($this->rootDirectory.'/'.self::OPEN_API_PATH)) {
+            $file = $this->rootDirectory.'/'.self::OPEN_API_PATH;
+        } else {
+            $file = self::OPEN_API_TEMPLATE_PATH;
+        }
+
+        return Yaml::parseFile($file);
+    }
+}

--- a/src/Collection/PostmanCollectionGenerator.php
+++ b/src/Collection/PostmanCollectionGenerator.php
@@ -50,7 +50,13 @@ class PostmanCollectionGenerator extends CollectionGeneratorAbstract
 
         $collection = $this->LoadOldCollection();
 
-        $collection['item'][] = $directory;
+        $index = $this->alreadyExists($collection, $directory);
+
+        if (null === $index) {
+            $collection['item'][] = $directory;
+        } else {
+            $collection['item'][$index] = $directory;
+        }
 
         $this->fileManager->dumpFile(self::POSTMAN_PATH, json_encode($collection, JSON_PRETTY_PRINT));
 
@@ -126,5 +132,16 @@ class PostmanCollectionGenerator extends CollectionGeneratorAbstract
         }
 
         return $collection;
+    }
+
+    private function alreadyExists(array $collection, array $directory): ?int
+    {
+        foreach ($collection['item'] as $index => $item) {
+            if ($item['name'] === $directory['name']) {
+                return $index;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Collection/SwaggerCollectionGenerator.php
+++ b/src/Collection/SwaggerCollectionGenerator.php
@@ -20,6 +20,8 @@ class SwaggerCollectionGenerator extends CollectionGeneratorAbstract
 
     public function generateCollection(ClassMetadataInfo $classMetadata, string $entityName, string $route): string
     {
+        $this->setSeed(12345678);
+
         $this->swagger = new Swagger($this->loadOldCollection());
 
         $this->fields = Attributes::parse($classMetadata);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('json_api');
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode
+            ->children()
+            ->scalarNode('documentationSchema')->defaultValue('swagger')->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/JsonApiExtension.php
+++ b/src/DependencyInjection/JsonApiExtension.php
@@ -21,5 +21,10 @@ class JsonApiExtension extends Extension
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $definition = $container->getDefinition('maker.maker.make_api');
+        $definition->setArgument(0, $config['documentationSchema']);
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -32,10 +32,17 @@
             <argument>%kernel.project_dir%</argument>
         </service>
 
+        <service id="jsonapi.open_api_collection_generator" class="Paknahad\JsonApiBundle\Collection\OpenApiCollectionGenerator">
+            <argument type="service" id="maker.file_manager" />
+            <argument>%kernel.project_dir%</argument>
+        </service>
+
         <service id="maker.maker.make_api" class="Paknahad\JsonApiBundle\Maker\ApiCrud">
             <tag name="maker.command" />
+            <argument/>
             <argument type="service" id="jsonapi.postman_collection_generator" />
             <argument type="service" id="jsonapi.swagger_collection_generator" />
+            <argument type="service" id="jsonapi.open_api_collection_generator" />
             <argument type="service" id="maker.doctrine_helper" />
         </service>
 

--- a/src/Resources/skeleton/open_api.yaml
+++ b/src/Resources/skeleton/open_api.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  description: "This is where you can give more detailed description of your API"
+  version: "1.0.0"
+  title: "Openapi JsonApi"
+  termsOfService: "http://swagger.io/terms/"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+paths:
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io"
+servers:
+  - url: http://localhost:8000/api
+    description: Local Environment
+components:
+  securitySchemes:
+    bearerToken:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:


### PR DESCRIPTION
Hi, as stated in #53 this is the PR to add openapi documentation schema generation. Documentation schema is switchable with configuration like this:

```yaml
# json_api.yaml
json_api:
    documentationSchema: 'openapi'
```
Generated schema is tested as valid on swagger.com (generated on two entites in relation with one another)
