### PR TITLE
Fix sorting by deep relationships

### DIFF
--- a/src/Helper/FieldManager.php
+++ b/src/Helper/FieldManager.php
@@ -115,12 +115,14 @@ class FieldManager
         }
 
         $this->fields[$fieldName] = $this->parseField($fieldName);
-
         $this->setRelations($fieldName);
-        $relation = $this->relations[$this->fields[$fieldName]['entity']];
+
+        $relation = $this->getRelevantRelationFromFieldData($this->fields[$fieldName]);
         $this->fields[$fieldName]['relation_alias'] = $relation['alias'];
 
-        $this->fields[$fieldName]['metadata'] = $this->getFieldMetaData($this->fields[$fieldName]['entity'], $this->fields[$fieldName]['field']);
+        $entity = $relation['entity'] ?? $this->fields[$fieldName]['entity'];
+
+        $this->fields[$fieldName]['metadata'] = $this->getFieldMetaData($entity, $this->fields[$fieldName]['field']);
 
         return $this->fields[$fieldName];
     }
@@ -268,5 +270,18 @@ class FieldManager
         $associations = $this->entityManager->getClassMetadata($sourceEntity)->associationMappings;
 
         return $associations[$entity] ?? [];
+    }
+
+    protected function getRelevantRelationFromFieldData(array $fieldData): array
+    {
+        $entityPath = $fieldData['entity-path'];
+
+        if (count($entityPath) === 0) {
+            return $this->relations[$fieldData['entity']];
+        }
+
+        $relevantRelationEntity = $entityPath[count($entityPath)-1];
+
+        return $this->relations[$relevantRelationEntity];
     }
 }

--- a/src/Helper/ResourceCollection.php
+++ b/src/Helper/ResourceCollection.php
@@ -176,17 +176,35 @@ class ResourceCollection implements IteratorAggregate, PaginationLinkProviderInt
     protected function addRelationsToQuery()
     {
         $relations = $this->fieldManager->getRelations();
+
+        $formattedRelations = $this->getFormattedRelations($relations);
+
         foreach ($relations as $entity => $relation) {
             if ($entity === $this->fieldManager->getRootEntity()) {
                 continue;
             }
 
             $sourceAlias = FieldManager::ROOT_ALIAS;
-            if ($relations[$relation['entity']]['sourceEntity'] !== $this->fieldManager->getRootEntity()) {
-                $sourceAlias = $relations[$relation['entity']]['alias'];
+            $relationSourceEntity = $relations[$relation['entity']]['sourceEntity'];
+            if ($relationSourceEntity !== $this->fieldManager->getRootEntity()) {
+                $sourceAlias = $formattedRelations[$relationSourceEntity]['alias'];
             }
 
             $this->query->leftJoin(sprintf('%s.%s', $sourceAlias, $relation['entity']), $relation['alias']);
         }
+    }
+
+    /**
+     * Format relations to use entityClass as array key
+     */
+    protected function getFormattedRelations(array $relations): array
+    {
+        $formattedRelations = [];
+
+        foreach ($relations as $relation) {
+            $formattedRelations[$relation['entityClass']] = $relation;
+        }
+
+        return $formattedRelations;
     }
 }


### PR DESCRIPTION
Hi,

after we tried a few advanced examples with sorting and filtering on our project, we found out that sorting will work only for fields of root object and first-level relationships. The current implementation ignores any additional relationship (second-level and further) and produces an internal error.

This PR should fix this restriction and allow much more complex sortings.

Example:
`?sort=expenses.user.name,-expenses.amount`