### PR TITLE
Add phpunit cache file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /var/
 /tests/tmp/*
 /.php_cs.cache
+/.phpunit.result.cache


### PR DESCRIPTION
Hi,

after running the test suite locally, PHPUnit (from version 8+) now generates a cache file to speed-up future checks. I added it to .gitignore as recommended [here](https://stackoverflow.com/questions/55091768/what-is-phpunit-result-cache).