### PR TITLE
Add support for showing meta fields when APP_DEBUG var is set to true

### DIFF
--- a/src/EventSubscriber/JsonApiErrorHandlerEvent.php
+++ b/src/EventSubscriber/JsonApiErrorHandlerEvent.php
@@ -26,10 +26,13 @@ class JsonApiErrorHandlerEvent implements EventSubscriberInterface
 
     private $jsonApi;
 
-    public function __construct($environment, JsonApi $jsonApi)
+    private $debug;
+
+    public function __construct($environment, JsonApi $jsonApi, $debug)
     {
         $this->environment = $environment;
         $this->jsonApi = $jsonApi;
+        $this->debug = $debug;
     }
 
     public static function getSubscribedEvents()
@@ -54,7 +57,7 @@ class JsonApiErrorHandlerEvent implements EventSubscriberInterface
             new JsonSerializer()
         );
 
-        $additionalMeta = \in_array($this->environment, ['dev', 'test']) ? $this->getExceptionMeta($exception) : [];
+        $additionalMeta = \in_array($this->environment, ['dev', 'test']) || $this->debug === true ? $this->getExceptionMeta($exception) : [];
 
         $response = $responder->genericError(
             $this->toErrorDocument($exception, $event->getRequest()->getRequestUri()),

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,6 +11,7 @@
             <tag name="event_subscriber" />
             <argument type="service" id="WoohooLabs\Yin\JsonApi\JsonApi" />
             <argument key="$environment">%kernel.environment%</argument>
+            <argument key="$debug">%kernel.debug%</argument>
         </service>
 
         <service id="jsonapi.jsonApi.factory" class="Paknahad\JsonApiBundle\Factory\JsonApiFactory">


### PR DESCRIPTION
This PR adds support for controlling the visibility of meta fields by setting the APP_DEBUG environment variable to _true_.

Changes:
- inject the kernel.debug variable into JsonApiErrorHandlerEvent
- add a check when generating the meta field