### PR TITLE
Fix error status code

### DIFF
--- a/src/Exception/AbstractJsonApiValidationException.php
+++ b/src/Exception/AbstractJsonApiValidationException.php
@@ -37,7 +37,7 @@ abstract class AbstractJsonApiValidationException extends Exception implements J
 
         $error->setSource($errorSource)
             ->setDetail('Invalid value')
-            ->setStatus('');
+            ->setStatus((string) $this->code);
 
         return $error;
     }


### PR DESCRIPTION
Hi,

This PR should fix an issue which occurs when exception which extends `AbstractJsonApiValidationException` is thrown. 

This abstract class has `generateValidationError` method which generates Error instance but with an empty string as status code. Later on, this is converted to integer 0 and you get an error: Status code has to be an integer between 100 and 599. 

