### PR TITLE
Add new argument to validateFields which enforces validation only on specified fields

### DIFF
--- a/src/Hydrator/ValidatorTrait.php
+++ b/src/Hydrator/ValidatorTrait.php
@@ -73,15 +73,19 @@ trait ValidatorTrait
     }
 
     /**
-     * Validate all fields.
+     * Validate resource fields.
      *
      * @throws InvalidAttributeException
      */
-    protected function validateFields(ClassMetadata $metadata, JsonApiRequestInterface $request, bool $validExistence = true): void
+    protected function validateFields(ClassMetadata $metadata, JsonApiRequestInterface $request, bool $validExistence = true, array $fields = null): void
     {
         $this->validator = Validation::createValidator();
 
         foreach ($request->getResourceAttributes() as $field => $value) {
+            if (null !== $fields && !\in_array($field, $fields)) {
+                continue;
+            }
+
             if ($validExistence && !$metadata->hasField($field)) {
                 throw new ValidatorException('This attribute does not exist');
             }
@@ -92,7 +96,7 @@ trait ValidatorTrait
                 /** @var ConstraintViolationListInterface $validation */
                 $validation = $this->{$validator}($value);
                 if ($validation->count() > 0) {
-                    throw new InvalidAttributeException($field, $value, $validation->get(0)->getMessage(), 422);
+                    throw new InvalidAttributeException($field, $value);
                 }
             }
         }

--- a/src/Test/Constraint/IsValidJsonApi.php
+++ b/src/Test/Constraint/IsValidJsonApi.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\Constraint\Constraint;
  */
 class IsValidJsonApi extends Constraint
 {
-    /** @var ValidationResult $result */
+    /** @var ValidationResult */
     private $result;
 
     /**


### PR DESCRIPTION
Hi,

I added a new argument to `validateFields` which specifies fields that need to be validated. Main usage for this should be when an entity has virtual fields that are not stored in DB. Right now even with `validExistence` set to false, you get an error because ClassMeta doesn't recognize virtual fields.

The default value is set to `null` or all fields, so we don't have any breaking changes.