### PR TITLE
Add option to change controller namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,31 @@ has responses like this:
 ```
 NOTICE: the "meta" field gets filled just on development environment.
 
+## Configuration
+
+You can configure this bundle with following options:
+
+```yaml
+#config/packages/json_api.yaml
+
+json_api:
+    documentationSchema: 'openapi'
+    controllerNamespace: 'Controller'
+```
+Supported documentation schemas are `openapi` and `swagger`.
+If you want to generate controllers in a different namespace, for example `Controller\Api` you can use controllerNamespace configuration option.
+To prefix Api routes you can use Symfony routes configuration:
+```yaml
+#config/routes/annotations.yaml
+
+api:
+    resource: ../../src/Controller/Api
+    type: annotation
+    prefix: /api
+
+```
+
+
 [1]: https://symfony.com/
 [2]: http://jsonapi.org/
 [3]: https://github.com/woohoolabs/yin

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,6 +14,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
             ->scalarNode('documentationSchema')->defaultValue('swagger')->end()
+            ->scalarNode('controllerNamespace')->defaultValue('Controller\\')->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/JsonApiExtension.php
+++ b/src/DependencyInjection/JsonApiExtension.php
@@ -26,5 +26,6 @@ class JsonApiExtension extends Extension
 
         $definition = $container->getDefinition('maker.maker.make_api');
         $definition->setArgument(0, $config['documentationSchema']);
+        $definition->setArgument(1, $config['controllerNamespace']);
     }
 }

--- a/src/Maker/ApiCrud.php
+++ b/src/Maker/ApiCrud.php
@@ -46,9 +46,14 @@ final class ApiCrud extends AbstractMaker
      * @var \Doctrine\Inflector\Inflector
      */
     private $inflector;
+    /**
+     * @var string
+     */
+    private $controllerNamespace;
 
     public function __construct(
         string $documentationSchema,
+        string $controllerNamespace,
         PostmanCollectionGenerator $postmanGenerator,
         SwaggerCollectionGenerator $swaggerGenerator,
         OpenApiCollectionGenerator $openApiCollectionGenerator,
@@ -63,6 +68,7 @@ final class ApiCrud extends AbstractMaker
         $this->documentationSchema = $documentationSchema;
 
         $this->inflector = $languageInflectorFactory->build();
+        $this->controllerNamespace = $controllerNamespace;
     }
 
     public static function getCommandName(): string
@@ -138,7 +144,7 @@ final class ApiCrud extends AbstractMaker
 
         $controllerClassDetails = $generator->createClassNameDetails(
             $entityVarSingular,
-            'Controller\\',
+            $this->controllerNamespace.'\\',
             'Controller'
         );
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -45,6 +45,7 @@
         <service id="maker.maker.make_api" class="Paknahad\JsonApiBundle\Maker\ApiCrud">
             <tag name="maker.command" />
             <argument/>
+            <argument/>
             <argument type="service" id="jsonapi.postman_collection_generator" />
             <argument type="service" id="jsonapi.swagger_collection_generator" />
             <argument type="service" id="jsonapi.open_api_collection_generator" />


### PR DESCRIPTION
This PR adds a configuration option to change the namespace and folder of generated Controller class. If omitted, it defaults to Controller.
```yaml
#config/packages/json_api.yaml

json_api:
    documentationSchema: 'openapi'
    controllerNamespace: 'Controller\Api'
```

To add a route prefix in Symfony 5.*, as asked in #54 by @cdubz you should add this to symfony route configuration.
```yaml
#config/routes/annotations.yaml

api:
    resource: ../../src/Controller/Api
    type: annotation
    prefix: /api

```
This way you keep the option of having a non-api routes, as well as changing the api prefix later on. This solution is cleaner than adding `/api` to each controller generated by this bundle.