### PR TITLE
Fix ConstraintValidationList

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -5,7 +5,7 @@ namespace Paknahad\JsonApiBundle\Controller;
 use Paknahad\JsonApiBundle\Transformer;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use WoohooLabs\Yin\JsonApi\JsonApi;
 use WoohooLabs\Yin\JsonApi\Schema\Document\ErrorDocument;
 use WoohooLabs\Yin\JsonApi\Schema\Error\Error;
@@ -26,7 +26,7 @@ class Controller extends AbstractController
         return $this->jsonApi;
     }
 
-    protected function validationErrorResponse(ConstraintViolationList $errors): ResponseInterface
+    protected function validationErrorResponse(ConstraintViolationListInterface $errors): ResponseInterface
     {
         $errorDocument = new ErrorDocument();
         $errorDocument->setJsonApi(new JsonApiObject('1.0'));

--- a/src/Resources/skeleton/api/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/api/controller/Controller.tpl.php
@@ -47,7 +47,6 @@ class <?= $class_name ?> extends Controller
 
         $<?= $entity_var_name ?> = $this->jsonApi()->hydrate(new <?= $create_hydrator_class_name ?>($entityManager, $exceptionFactory), new <?= $entity_class_name ?>());
 
-        /** @var ConstraintViolationList $errors */
         $errors = $validator->validate($<?= $entity_var_name ?>);
         if ($errors->count() > 0) {
             return $this->validationErrorResponse($errors);

--- a/src/Resources/skeleton/api/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/api/controller/Controller.tpl.php
@@ -14,7 +14,6 @@ use Paknahad\JsonApiBundle\Helper\ResourceCollection;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory;
 
@@ -83,7 +82,6 @@ class <?= $class_name ?> extends Controller
 
         $<?= $entity_var_name ?> = $this->jsonApi()->hydrate(new <?= $update_hydrator_class_name ?>($entityManager, $exceptionFactory), $<?= $entity_var_name ?>);
 
-        /** @var ConstraintViolationList $errors */
         $errors = $validator->validate($<?= $entity_var_name ?>);
         if ($errors->count() > 0) {
             return $this->validationErrorResponse($errors);


### PR DESCRIPTION
This PR swaps ConstraintValidationList with ConstraintViolationListInterface in generated controller since it is what `$validator->validate()` returns. This also removes dependency.