### PR TITLE
Use validation exception instead of building response in a Controller

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -2,10 +2,12 @@
 
 namespace Paknahad\JsonApiBundle\Controller;
 
+use Paknahad\JsonApiBundle\Exception\ValidationException;
 use Paknahad\JsonApiBundle\Transformer;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WoohooLabs\Yin\JsonApi\JsonApi;
 use WoohooLabs\Yin\JsonApi\Schema\Document\ErrorDocument;
 use WoohooLabs\Yin\JsonApi\Schema\Error\Error;
@@ -15,10 +17,15 @@ use WoohooLabs\Yin\JsonApi\Schema\JsonApiObject;
 class Controller extends AbstractController
 {
     private $jsonApi;
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
 
-    public function __construct(JsonApi $jsonApi)
+    public function __construct(JsonApi $jsonApi, ValidatorInterface $validator)
     {
         $this->jsonApi = $jsonApi;
+        $this->validator = $validator;
     }
 
     protected function jsonApi(): JsonApi
@@ -26,6 +33,20 @@ class Controller extends AbstractController
         return $this->jsonApi;
     }
 
+    /**
+     * @param mixed $object
+     */
+    protected function validate($object): void
+    {
+        $errors = $this->validator->validate($object);
+        if ($errors->count() > 0) {
+            throw new ValidationException($errors);
+        }
+    }
+
+    /**
+     * @deprecated This function is deprecated. Use validate() instead.
+     */
     protected function validationErrorResponse(ConstraintViolationListInterface $errors): ResponseInterface
     {
         $errorDocument = new ErrorDocument();

--- a/src/Document/ValidationErrorDocument.php
+++ b/src/Document/ValidationErrorDocument.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Document;
+
+use Paknahad\JsonApiBundle\Transformer;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use WoohooLabs\Yin\JsonApi\Schema\Document\ErrorDocument;
+use WoohooLabs\Yin\JsonApi\Schema\Error\Error;
+use WoohooLabs\Yin\JsonApi\Schema\Error\ErrorSource;
+use WoohooLabs\Yin\JsonApi\Schema\JsonApiObject;
+
+class ValidationErrorDocument extends ErrorDocument
+{
+    const STATUS_CODE = 422;
+
+    public function __construct(ConstraintViolationListInterface $errors)
+    {
+        parent::__construct();
+        $this->setJsonApi(new JsonApiObject('1.0'));
+        /** @var ConstraintViolation $fieldError */
+        foreach ($errors as $fieldError) {
+            $error = Error::create();
+            $pointer = '/data/attributes/'.$fieldError->getPropertyPath();
+
+            $errorSource = new ErrorSource(
+                $pointer,
+                Transformer::validationValueToString($fieldError->getInvalidValue())
+            );
+
+            $error->setSource($errorSource)
+                ->setDetail($fieldError->getMessage())
+                ->setStatus('');
+
+            $this->addError($error);
+        }
+    }
+
+    public function getStatusCode(?int $statusCode = null): int
+    {
+        return self::STATUS_CODE;
+    }
+}

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Exception;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Exception\RuntimeException;
+
+class ValidationException extends RuntimeException
+{
+    private $violations;
+
+    public function __construct(ConstraintViolationListInterface $violations)
+    {
+        $this->violations = $violations;
+        parent::__construct($violations);
+    }
+
+    public function getViolations(): ConstraintViolationListInterface
+    {
+        return $this->violations;
+    }
+}

--- a/src/Resources/skeleton/api/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/api/controller/Controller.tpl.php
@@ -14,7 +14,6 @@ use Paknahad\JsonApiBundle\Helper\ResourceCollection;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory;
 
 /**
@@ -40,16 +39,13 @@ class <?= $class_name ?> extends Controller
     /**
      * @Route("/", name="<?= $route_name ?>_new", methods="POST")
      */
-    public function new(ValidatorInterface $validator, DefaultExceptionFactory $exceptionFactory): ResponseInterface
+    public function new(DefaultExceptionFactory $exceptionFactory): ResponseInterface
     {
         $entityManager = $this->getDoctrine()->getManager();
 
         $<?= $entity_var_name ?> = $this->jsonApi()->hydrate(new <?= $create_hydrator_class_name ?>($entityManager, $exceptionFactory), new <?= $entity_class_name ?>());
 
-        $errors = $validator->validate($<?= $entity_var_name ?>);
-        if ($errors->count() > 0) {
-            return $this->validationErrorResponse($errors);
-        }
+        $this->validate($<?= $entity_var_name ?>);
 
         $entityManager->persist($<?= $entity_var_name ?>);
         $entityManager->flush();
@@ -76,16 +72,13 @@ class <?= $class_name ?> extends Controller
     /**
      * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_edit", methods="PATCH")
      */
-    public function edit(<?= $entity_class_name ?> $<?= $entity_var_name ?>, ValidatorInterface $validator, DefaultExceptionFactory $exceptionFactory): ResponseInterface
+    public function edit(<?= $entity_class_name ?> $<?= $entity_var_name ?>, DefaultExceptionFactory $exceptionFactory): ResponseInterface
     {
         $entityManager = $this->getDoctrine()->getManager();
 
         $<?= $entity_var_name ?> = $this->jsonApi()->hydrate(new <?= $update_hydrator_class_name ?>($entityManager, $exceptionFactory), $<?= $entity_var_name ?>);
 
-        $errors = $validator->validate($<?= $entity_var_name ?>);
-        if ($errors->count() > 0) {
-            return $this->validationErrorResponse($errors);
-        }
+        $this->validate($<?= $entity_var_name ?>);
 
         $entityManager->flush();
 


### PR DESCRIPTION
Hi!

This PR changes the way validation response is built. Previous code relied upon a function in base `Controller` class that builds the validation response. That approach had a couple of problems:
* You have to inject `ValidatorInterface` to every POST/PATCH route.
* You have to check manually in every route if there are any validation errors. This forces you to repeat the same logic in every route in your application (4 lines of code).
* you are handling error case outside  `JsonApiErrorHandlerEvent` class.

With this PR, `validate()` function is added to base controller that throws `ValidationExeption`. Then, the logic that builds JsonApi error response is moved to `JsonApiErrorHandlerEvent` and `ValidationErrorDocument`.

This removes some unnecessary repeating of logic in every specific Controller class and  `ValidatorInterface` dependency. Also, 
it moves the rest of the logic to the right place. Original `validationErrorResponse()` function is not removed, but marked as deprecated to keep the bundle backward compatible.
