### PR TITLE
Implement methods in base hydrator instead of generating them

### DIFF
--- a/src/Hydrator/AbstractHydrator.php
+++ b/src/Hydrator/AbstractHydrator.php
@@ -3,17 +3,82 @@
 namespace Paknahad\JsonApiBundle\Hydrator;
 
 use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface;
 use WoohooLabs\Yin\JsonApi\Hydrator\AbstractHydrator as BaseHydrator;
+use WoohooLabs\Yin\JsonApi\Request\JsonApiRequestInterface;
 
 abstract class AbstractHydrator extends BaseHydrator
 {
+    use ValidatorTrait;
+
+    /**
+     * @var ObjectManager
+     */
     protected $objectManager;
+    /**
+     * @var ExceptionFactoryInterface
+     */
     protected $exceptionFactory;
 
     public function __construct(ObjectManager $objectManager, ExceptionFactoryInterface $exceptionFactory)
     {
         $this->objectManager = $objectManager;
         $this->exceptionFactory = $exceptionFactory;
+    }
+
+    /**
+     * Should return Entity::class.
+     */
+    protected function getClass(): string
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function validateClientGeneratedId(
+        string $clientGeneratedId,
+        JsonApiRequestInterface $request,
+        ExceptionFactoryInterface $exceptionFactory
+    ): void {
+        if (!empty($clientGeneratedId)) {
+            throw $exceptionFactory->createClientGeneratedIdNotSupportedException($request, $clientGeneratedId);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function validateRequest(JsonApiRequestInterface $request): void
+    {
+        $this->validateFields($this->objectManager->getClassMetadata($this->getClass()), $request);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setId($object, string $id): void
+    {
+        if ($id && (string) $object->getId() !== $id) {
+            throw new NotFoundHttpException('both ids in url & body must be the same');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function generateId(): string
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAttributeHydrator($object): array
+    {
+        return [];
     }
 }

--- a/src/Resources/skeleton/api/JsonApi/Hydrator/AbstractEntityHydrator.tpl.php
+++ b/src/Resources/skeleton/api/JsonApi/Hydrator/AbstractEntityHydrator.tpl.php
@@ -19,15 +19,12 @@ use <?= $entity_full_class_name ?>;
     }
 ?>
 use Paknahad\JsonApiBundle\Hydrator\AbstractHydrator;
-use Paknahad\JsonApiBundle\Hydrator\ValidatorTrait;
 <?php
     if (isset($useOneRelation)) {
         echo 'use Paknahad\JsonApiBundle\Exception\InvalidRelationshipValueException;
 ';
     }
 ?>
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface;
 <?php
     if (isset($useManyRelation)) {
         echo 'use WoohooLabs\Yin\JsonApi\Hydrator\Relationship\ToManyRelationship;
@@ -39,34 +36,19 @@ use WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface;
 ';
     }
 ?>
-use WoohooLabs\Yin\JsonApi\Request\JsonApiRequestInterface;
 
 /**
  * Abstract <?= $entity_class_name ?> Hydrator.
  */
 abstract class Abstract<?= $entity_class_name ?>Hydrator extends AbstractHydrator
 {
-    use ValidatorTrait;
 
     /**
      * {@inheritdoc}
      */
-    protected function validateClientGeneratedId(
-        string $clientGeneratedId,
-        JsonApiRequestInterface $request,
-        ExceptionFactoryInterface $exceptionFactory
-    ): void {
-        if (!empty($clientGeneratedId)) {
-            throw $exceptionFactory->createClientGeneratedIdNotSupportedException($request, $clientGeneratedId);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function generateId(): string
+    protected function getClass(): string
     {
-        return '';
+        return <?= $entity_class_name ?>::class;
     }
 
     /**
@@ -75,32 +57,6 @@ abstract class Abstract<?= $entity_class_name ?>Hydrator extends AbstractHydrato
     protected function getAcceptedTypes(): array
     {
         return ['<?= $entity_type_var_plural ?>'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getAttributeHydrator($<?= $entity_var_name ?>): array
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function validateRequest(JsonApiRequestInterface $request): void
-    {
-        $this->validateFields($this->objectManager->getClassMetadata(<?= $entity_class_name ?>::class), $request);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setId($<?= $entity_var_name ?>, string $id): void
-    {
-        if ($id && (string) $<?= $entity_var_name ?>->getId() !== $id) {
-            throw new NotFoundHttpException('both ids in url & body must be the same');
-        }
     }
 
     /**


### PR DESCRIPTION
This PR moves methods that are the same in each generated hydrator to AbstractHydrator class. This removes a lot of duplicated code that gets generated in the project.

These changes should be backward compatible and not limit the expandability in any way since all of the methods can be overridden if necessary.