### PR TITLE
Move duplicated code to abstract Document classes

### DIFF
--- a/src/Document/AbstractCollectionDocument.php
+++ b/src/Document/AbstractCollectionDocument.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Document;
+
+use WoohooLabs\Yin\JsonApi\Schema\Document\AbstractCollectionDocument as BaseDocument;
+use WoohooLabs\Yin\JsonApi\Schema\JsonApiObject;
+
+abstract class AbstractCollectionDocument extends BaseDocument
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getJsonApi(): ?JsonApiObject
+    {
+        return new JsonApiObject('1.0');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMeta(): array
+    {
+        return [];
+    }
+}

--- a/src/Document/AbstractSingleResourceDocument.php
+++ b/src/Document/AbstractSingleResourceDocument.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Paknahad\JsonApiBundle\Document;
+
+use WoohooLabs\Yin\JsonApi\Schema\Document\AbstractSingleResourceDocument as BaseDocument;
+use WoohooLabs\Yin\JsonApi\Schema\JsonApiObject;
+
+abstract class AbstractSingleResourceDocument extends BaseDocument
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getJsonApi(): ?JsonApiObject
+    {
+        return new JsonApiObject('1.0');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMeta(): array
+    {
+        return [];
+    }
+}

--- a/src/Resources/skeleton/api/JsonApi/Document/EntitiesDocument.tpl.php
+++ b/src/Resources/skeleton/api/JsonApi/Document/EntitiesDocument.tpl.php
@@ -2,8 +2,7 @@
 
 namespace <?= $namespace ?>;
 
-use WoohooLabs\Yin\JsonApi\Schema\Document\AbstractCollectionDocument;
-use WoohooLabs\Yin\JsonApi\Schema\JsonApiObject;
+use Paknahad\JsonApiBundle\Document\AbstractCollectionDocument;
 use WoohooLabs\Yin\JsonApi\Schema\Link\DocumentLinks;
 
 /**
@@ -11,22 +10,6 @@ use WoohooLabs\Yin\JsonApi\Schema\Link\DocumentLinks;
  */
 class <?= $entity_class_name_plural ?>Document extends AbstractCollectionDocument
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getJsonApi(): ?JsonApiObject
-    {
-        return new JsonApiObject('1.0');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMeta(): array
-    {
-        return [];
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Resources/skeleton/api/JsonApi/Document/EntityDocument.tpl.php
+++ b/src/Resources/skeleton/api/JsonApi/Document/EntityDocument.tpl.php
@@ -2,8 +2,7 @@
 
 namespace <?= $namespace ?>;
 
-use WoohooLabs\Yin\JsonApi\Schema\Document\AbstractSingleResourceDocument;
-use WoohooLabs\Yin\JsonApi\Schema\JsonApiObject;
+use Paknahad\JsonApiBundle\Document\AbstractSingleResourceDocument;
 use WoohooLabs\Yin\JsonApi\Schema\Link\DocumentLinks;
 use WoohooLabs\Yin\JsonApi\Schema\Link\Link;
 
@@ -12,22 +11,6 @@ use WoohooLabs\Yin\JsonApi\Schema\Link\Link;
  */
 class <?= $entity_class_name ?>Document extends AbstractSingleResourceDocument
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getJsonApi(): ?JsonApiObject
-    {
-        return new JsonApiObject('1.0');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMeta(): array
-    {
-        return [];
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
This PR moves the code that is repeated in every generated Document class to Abstract class, the same way it is done in hydrators.
These changes are backward compatible.