### PR TITLE
Update README.md to use correct version of jsonapi-bundle and not the strict 3.0.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ JsonApiBundle is a [Symfony][1] bundle. It is the fastest way to generate API ba
     ```
     For Symfony 4 use:
     ```
-    composer require paknahad/jsonapi-bundle:^3
+    composer require paknahad/jsonapi-bundle:^3.1
     ```
 
 4. Add below line to ``config/bundles.php``

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ JsonApiBundle is a [Symfony][1] bundle. It is the fastest way to generate API ba
     ```
     For Symfony 4 use:
     ```
-    composer require paknahad/jsonapi-bundle:3.0.0
+    composer require paknahad/jsonapi-bundle:^3
     ```
 
 4. Add below line to ``config/bundles.php``


### PR DESCRIPTION
When using the strict version require of 3.0.0 you won't get the latest version for Symfony 4. I noticed this, because the docs say:
```
By using $resourceCollection->getQuery() you can get access on the query object. use "r" alias for referring to the current entity. in this example the "r" refers to the "ProjectEntity"
```
But the code in tag 3.0.0 did not have the generateQuery() inside the setRepository() function. So normally getQuery returns a queryBuilder, but without the 'generateQuery()' function, getQuery will allways return NULL and therefore it's impossible to add a where condition to a query.
```
/**
     * Sets the Repository And makes query_object.
     *
     * @param entityRepository $repository
     *                                     The Repository
     */
    public function setRepository(EntityRepository $repository): void
    {
        $this->repository = $repository;

        $this->query = $this->generateQuery();
    }
```
Can you fix this in de docs? If you want to change the number to ^3.1, you can do this.