### PR TITLE
fix: unhandled undefined index

### DIFF
--- a/src/EventSubscriber/JsonApiErrorHandlerEvent.php
+++ b/src/EventSubscriber/JsonApiErrorHandlerEvent.php
@@ -74,7 +74,7 @@ class JsonApiErrorHandlerEvent implements EventSubscriberInterface
         $trace = [];
         foreach ($exception->getTrace() as $item) {
             $trace[] = [
-                'file' => $item['file'] ?? $item['class'],
+                'file' => $item['file'] ?? $item['class'] ?? 'undefined',
                 'line' => $item['line'] ?? 'undefined',
                 'function' => $item['function'] ?? 'undefined',
             ];


### PR DESCRIPTION
Unhandled undefined `file` or 'class' indexes in `JsonApiErrorHandlerEvent::getExceptionMeta()` method.

Instead of throwing an fatal error, it uses `'undefined'` when not defined, similar to `line` and `function` indexes, resulting in:

```json5
{
  "meta": {
    // ...
    "trace": [
      // ...
      { 
        "file": "undefined",
        "line": "undefined", 
        "function": "spl_autoload_call" 
      }
    ]
  },
  // ...
}
```

Fixes #88 