### PR TITLE
Add additionalMetaData to RespondOk response

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -61,7 +61,7 @@ class Controller extends AbstractController
     protected function respondOk(ResourceDocumentInterface $document, $object, array $additionalMeta = []): Response
     {
         return $this->respond(
-            $this->jsonApi()->respond()->ok($document, $object)
+            $this->jsonApi()->respond()->ok($document, $object, $additionalMeta)
         );
     }
 


### PR DESCRIPTION
`$additionalMeta` isnt being passed to the `ok()` method - not sure if that is intentional but PR is up for review